### PR TITLE
Allow customization of http config

### DIFF
--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClientModule.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClientModule.java
@@ -1,30 +1,16 @@
 package com.hubspot.slack.client;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
-import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
-import com.hubspot.horizon.HttpConfig;
-import com.hubspot.horizon.ning.NingAsyncHttpClient;
-import com.hubspot.slack.client.jackson.ObjectMapperUtils;
+import com.hubspot.slack.client.http.NioHttpClient;
 
 public class SlackClientModule extends AbstractModule {
   @Override
   protected void configure() {
+    install(new FactoryModuleBuilder().build(NioHttpClient.Factory.class));
     install(new FactoryModuleBuilder()
         .implement(SlackClient.class, SlackWebClient.class)
         .build(SlackWebClient.Factory.class));
-  }
-
-  @Slack
-  @Provides
-  @Singleton
-  public NingAsyncHttpClient providesHttpClient() {
-    return new NingAsyncHttpClient(
-        HttpConfig.newBuilder()
-            .setObjectMapper(ObjectMapperUtils.mapper())
-            .build()
-    );
   }
 
   @Override

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClientRuntimeConfigIF.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClientRuntimeConfigIF.java
@@ -5,6 +5,7 @@ import java.util.function.Supplier;
 
 import org.immutables.value.Value.Immutable;
 
+import com.hubspot.horizon.HttpConfig;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.interceptors.calls.SlackMethodAcceptor;
 import com.hubspot.slack.client.interceptors.http.RequestDebugger;
@@ -20,6 +21,8 @@ public interface SlackClientRuntimeConfigIF {
   Supplier<Integer> getChannelsListBatchSize();
   Supplier<Integer> getChannelsHistoryMessageBatchSize();
   Supplier<Integer> getConversationsHistoryMessageBatchSize();
+
+  Optional<HttpConfig> getHttpConfig();
 
   Optional<SlackMethodAcceptor> getMethodFilter();
 

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/http/NioHttpClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/http/NioHttpClient.java
@@ -5,21 +5,23 @@ import java.util.concurrent.CompletableFuture;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
-import com.google.inject.Singleton;
+import com.google.inject.assistedinject.Assisted;
 import com.hubspot.horizon.AsyncHttpClient;
 import com.hubspot.horizon.AsyncHttpClient.Callback;
 import com.hubspot.horizon.HttpRequest;
 import com.hubspot.horizon.HttpRequest.Options;
 import com.hubspot.horizon.HttpResponse;
-import com.hubspot.slack.client.Slack;
 
-@Singleton
 public class NioHttpClient {
   private final AsyncHttpClient delegate;
 
+  public interface Factory {
+    NioHttpClient wrap(@Assisted AsyncHttpClient delegate);
+  }
+
   @Inject
   public NioHttpClient(
-      @Slack AsyncHttpClient delegate
+      @Assisted AsyncHttpClient delegate
   ) {
     this.delegate = delegate;
   }


### PR DESCRIPTION
Exposes the underlying http configuration, so users can change the behavior here.