### PR TITLE
Don't #thenCompose in the same thread

### DIFF
--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClient.java
@@ -1,5 +1,6 @@
 package com.hubspot.slack.client;
 
+import java.io.Closeable;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -68,7 +69,7 @@ import com.hubspot.slack.client.models.response.users.UsersInfoResponse;
 import com.hubspot.slack.client.models.usergroups.SlackUsergroup;
 import com.hubspot.slack.client.models.users.SlackUser;
 
-public interface SlackClient {
+public interface SlackClient extends Closeable {
   // auth
   CompletableFuture<Result<AuthTestResponse, SlackError>> testAuth();
 

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/CloseableExecutorService.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/CloseableExecutorService.java
@@ -1,0 +1,121 @@
+package com.hubspot.slack.client.concurrency;
+
+import java.io.Closeable;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CloseableExecutorService implements ExecutorService, Closeable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(CloseableExecutorService.class);
+
+  private final ExecutorService delegate;
+  private final String name;
+  private final long shutdownTimeout;
+  private final TimeUnit timeUnit;
+
+  private CloseableExecutorService(ExecutorService delegate, String name, long shutdownTimeout, TimeUnit timeUnit) {
+    this.delegate = delegate;
+    this.name = name;
+    this.shutdownTimeout = shutdownTimeout;
+    this.timeUnit = timeUnit;
+  }
+
+  public static CloseableExecutorService wrap(ExecutorService executorService, String name, long shutdownTimeout, TimeUnit timeUnit) {
+    return new CloseableExecutorService(executorService, name, shutdownTimeout, timeUnit);
+  }
+
+  @Override
+  public void shutdown() {
+    delegate.shutdown();
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    return delegate.shutdownNow();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return delegate.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return delegate.isTerminated();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return delegate.awaitTermination(timeout, unit);
+  }
+
+  @Override
+  public <T> Future<T> submit(Callable<T> task) {
+    return delegate.submit(task);
+  }
+
+  @Override
+  public <T> Future<T> submit(Runnable task, T result) {
+    return delegate.submit(task, result);
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    return delegate.submit(task);
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+    return delegate.invokeAll(tasks);
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks,
+                                       long timeout, TimeUnit unit) throws InterruptedException {
+    return delegate.invokeAll(tasks, timeout, unit);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+    return delegate.invokeAny(tasks);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks,
+                         long timeout,
+                         TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    return delegate.invokeAny(tasks, timeout, unit);
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    delegate.execute(command);
+  }
+
+  @Override
+  public void close() {
+    // This is basically stolen from the ExecutorService javadoc with some slight modifications
+    if (!isTerminated()) {
+      shutdown();
+      try {
+        if (!awaitTermination(shutdownTimeout, timeUnit)) {
+          shutdownNow();
+          if (!awaitTermination(shutdownTimeout, timeUnit)) {
+            LOGGER.error("{}: Tasks in executor failed to terminate in time, continuing with shutdown regardless.", name);
+          }
+        }
+      } catch (InterruptedException ie) {
+        shutdownNow();
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+}

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/FollowThreadLocalsExecutorService.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/FollowThreadLocalsExecutorService.java
@@ -1,0 +1,73 @@
+package com.hubspot.slack.client.concurrency;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.google.common.util.concurrent.ForwardingExecutorService;
+
+public class FollowThreadLocalsExecutorService extends ForwardingExecutorService implements FollowThreadsMixin {
+  private final ExecutorService delegate;
+  private final String namePrefix;
+
+  public FollowThreadLocalsExecutorService(ExecutorService delegate, String namePrefix) {
+    this.delegate = delegate;
+    this.namePrefix = namePrefix;
+  }
+
+  @Override
+  public String getNamePrefix() {
+    return namePrefix;
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+    return delegate().invokeAll(transformRequests(tasks));
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+    return delegate().invokeAll(transformRequests(tasks), timeout, unit);
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+    return delegate().invokeAny(transformRequests(tasks));
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    return delegate().invokeAny(transformRequests(tasks), timeout, unit);
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    delegate().execute(transformRequest(command));
+  }
+
+  @Override
+  public <T> Future<T> submit(Callable<T> task) {
+    return delegate().submit(transformRequest(task));
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    return delegate().submit(transformRequest(task));
+  }
+
+  @Override
+  public <T> Future<T> submit(Runnable task, T result) {
+    return delegate().submit(transformRequest(task), result);
+  }
+
+  @Override
+  protected ExecutorService delegate() {
+    return delegate;
+  }
+
+}

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/FollowThreadsMixin.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/FollowThreadsMixin.java
@@ -1,0 +1,47 @@
+package com.hubspot.slack.client.concurrency;
+
+import java.util.Collection;
+import java.util.concurrent.Callable;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.Collections2;
+
+public interface FollowThreadsMixin {
+  String getNamePrefix();
+
+  default <T> Collection<? extends Callable<T>> transformRequests(Collection<? extends Callable<T>> tasks) {
+    return Collections2.transform(tasks, this::transformRequest);
+  }
+
+  default <T> Callable<T> transformRequest(Callable<T> callable) {
+    String namePrefix = getNamePrefix();
+    ThreadContextHook.Context currentContext = ThreadContextHook.INSTANCE.buildThreadContext(namePrefix);
+    return () -> {
+      ThreadContextHook.Context initializedContext = null;
+      try {
+        initializedContext = ThreadContextHook.INSTANCE.initializeThreadContext(namePrefix, currentContext);
+        return callable.call();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      } finally {
+        ThreadContextHook.INSTANCE.clearThreadContext(namePrefix, initializedContext);
+      }
+    };
+  }
+
+  default Runnable transformRequest(Runnable runnable) {
+    Callable<Void> callableVersion = () -> {
+      runnable.run();
+      return null;
+    };
+    Callable<Void> voidCallable = transformRequest(callableVersion);
+    return () -> {
+      try {
+        voidCallable.call();
+      } catch (Exception e) {
+        throw Throwables.propagate(e);
+      }
+    };
+  }
+
+}

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/LoggingUncaughtExceptionHandler.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/LoggingUncaughtExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.hubspot.slack.client.concurrency;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LoggingUncaughtExceptionHandler
+    implements Thread.UncaughtExceptionHandler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LoggingUncaughtExceptionHandler.class);
+
+  @Override
+  public void uncaughtException(Thread t, Throwable e) {
+    LOG.error("[thread={}] uncaught exception", t.getName(), e);
+  }
+
+}

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/MoreExecutors.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/MoreExecutors.java
@@ -1,0 +1,297 @@
+package com.hubspot.slack.client.concurrency;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+public final class MoreExecutors {
+  private static final Logger LOG = LoggerFactory.getLogger(MoreExecutors.class);
+
+  private static final AtomicBoolean HAS_WARNED_UNNAMED_THREADFACTORY = new AtomicBoolean(false);
+
+  private MoreExecutors() {}
+
+  /**
+   * An opinionated builder for a new executor.
+   * Rather than choosing between a cached executor, or a fixed
+   * executor, this gives you a default thread pool that scales
+   * from a core size to a max size with sensible defaults.
+   * <p>
+   * The only required parameter is a name for the thread factory,
+   * and by default the thread pool is daemon.
+   * <p>
+   * {@code
+   * <p>
+   * ExecutorService service = Executors2.threadPoolNonDaemonExecutorBuilder("my-pool")
+   * .setMaxSize(100)  // now we have 100 max threads
+   * .setBlockWhenFull(true) // will block once 100 tasks are being worked on
+   * .build();
+   * }
+   * <p>
+   * The name of the threads will be of the form "{namePrefix}-N" where N is an
+   * integer.
+   */
+  public static ThreadPoolExecutorBuilder threadPoolNonDaemonExecutorBuilder(String namePrefix) {
+    return new ThreadPoolExecutorBuilderImpl(namePrefix, false);
+  }
+
+  public static ThreadPoolExecutorBuilder threadPoolDaemonExecutorBuilder(String namePrefix) {
+    return new ThreadPoolExecutorBuilderImpl(namePrefix, true);
+  }
+
+  public interface ThreadPoolExecutorBuilder {
+    /**
+     * Sets the max number of threads in the thread pool.
+     * If blockWithNoQueue is true, this is the max number
+     * of items the service will hold. Any additional items
+     * will cause blocking.
+     * <p>
+     * Defaults to 20
+     */
+    ThreadPoolExecutorBuilder setMaxSize(int maxSize);
+
+    /**
+     * Sets the keep alive time. After the keep alive time
+     * has passed, the thread pool will scale down the threads
+     * to the core size.
+     * <p>
+     * Defaults to 1 minutes.
+     */
+    ThreadPoolExecutorBuilder setKeepAlive(long keepAlive, TimeUnit timeUnit);
+
+    /**
+     * Sets the work queue, which defaults to a LinkedBlockingQueue unless
+     * blockWhenFull is true.
+     * <p>
+     * DANGER! If you override the queue with blockWhenFull, be sure to set the
+     * capacity to coreSize + 1 if you value determinism.
+     */
+    ThreadPoolExecutorBuilder setWorkQueue(BlockingQueue<Runnable> workQueue);
+
+    /**
+     * Sets the queue to use a fixed set of threads.
+     * <p>
+     * If true, the thread pool will not timeout threads.
+     */
+    ThreadPoolExecutorBuilder setFixed(boolean fixed);
+
+    /**
+     * Enable block when full. This means that the executor service will
+     * block until there is room to actually run the task.
+     *
+     * @param backlogSize - The amount of pending tasks before blocking.
+     */
+    ThreadPoolExecutorBuilder setBlockWhenFull(int backlogSize);
+
+    /**
+     * If unbounded, the thread pool will behave like newCachedThreadPool().
+     * That is - 0 core size and infinite max size.
+     * <p>
+     * Defaults to false.
+     */
+    ThreadPoolExecutorBuilder setUnbounded(boolean unbounded);
+
+    /**
+     * Disable block when full. This will enable the unbounded queue
+     * with no blocking.
+     */
+    ThreadPoolExecutorBuilder clearBlockWhenFull();
+
+    /**
+     * If true, it will use a fair queue implementation for blockWhenFull.
+     */
+    ThreadPoolExecutorBuilder setFair(boolean fair);
+
+    /**
+     * Set whether or not to attempt to follow thread locals.
+     * (Default: TRUE)
+     */
+    ThreadPoolExecutorBuilder setFollowThreadLocals(boolean followThreadLocals);
+
+    /**
+     * Set the timeout for shutdown of this executor service
+     * Defaults to  30 seconds
+     */
+    ThreadPoolExecutorBuilder setShutdownTimeout(long timeout, TimeUnit timeUnit);
+
+    /**
+     * Build the executor service.
+     */
+    CloseableExecutorService build();
+  }
+
+  private static class ThreadPoolExecutorBuilderImpl implements ThreadPoolExecutorBuilder {
+    private final String namePrefix;
+    private final boolean daemon;
+    private boolean fair = false;
+    private boolean blockWhenFull = false;
+    private boolean fixed = true;
+    private boolean unbounded = false;
+    private int maxSize = 20;
+    private long keepAliveTime = 60;
+    private Optional<Integer> queueSize = Optional.absent();
+    private TimeUnit keepAliveTimeUnit = TimeUnit.SECONDS;
+    private BlockingQueue<Runnable> queue = null;
+    private boolean followThreadLocals = true;
+    private long shutdownTimeout = 30;
+    private TimeUnit shutdownTimeUnit = TimeUnit.SECONDS;
+
+    private ThreadPoolExecutorBuilderImpl(String namePrefix, boolean daemon) {
+      this.namePrefix = namePrefix;
+      this.daemon = daemon;
+    }
+
+    @Override
+    public ThreadPoolExecutorBuilder setFollowThreadLocals(boolean followThreadLocals) {
+      this.followThreadLocals = followThreadLocals;
+      return this;
+    }
+
+    @Override
+    public ThreadPoolExecutorBuilder setMaxSize(int maxSize) {
+      this.maxSize = maxSize;
+      return this;
+    }
+
+    @Override
+    public ThreadPoolExecutorBuilder setKeepAlive(long keepAlive, TimeUnit timeUnit) {
+      this.keepAliveTime = keepAlive;
+      this.keepAliveTimeUnit = timeUnit;
+      return this;
+    }
+
+    @Override
+    public ThreadPoolExecutorBuilder setWorkQueue(BlockingQueue<Runnable> workQueue) {
+      this.queue = workQueue;
+      return this;
+    }
+
+    @Override
+    public ThreadPoolExecutorBuilder setUnbounded(boolean unbounded) {
+      this.unbounded = unbounded;
+      return this;
+    }
+
+    @Override
+    public ThreadPoolExecutorBuilder setFixed(boolean fixed) {
+      this.fixed = fixed;
+      return this;
+    }
+
+    @Override
+    public ThreadPoolExecutorBuilder setBlockWhenFull(int queueSize) {
+      this.blockWhenFull = true;
+      this.queueSize = Optional.of(queueSize);
+      return this;
+    }
+
+    @Override
+    public ThreadPoolExecutorBuilder clearBlockWhenFull() {
+      this.blockWhenFull = false;
+      this.queueSize = Optional.absent();
+      return this;
+    }
+
+    @Override
+    public ThreadPoolExecutorBuilder setFair(boolean fair) {
+      this.fair = fair;
+      return this;
+    }
+
+    @Override
+    public ThreadPoolExecutorBuilder setShutdownTimeout(long timeout, TimeUnit timeUnit) {
+      this.shutdownTimeout = timeout;
+      this.shutdownTimeUnit = timeUnit;
+
+      return this;
+    }
+
+    @Override
+    public CloseableExecutorService build() {
+      ThreadPoolExecutor executor = new ThreadPoolExecutor(
+          unbounded ? 0 : maxSize,
+          unbounded ? Integer.MAX_VALUE : maxSize,
+          keepAliveTime,
+          keepAliveTimeUnit,
+          getQueue(),
+          buildThreadFactory(),
+          getRejectionPolicy());
+      if (!fixed) {
+        executor.allowCoreThreadTimeOut(true);
+      }
+
+      ExecutorService executorService;
+      if (followThreadLocals) {
+        executorService = new FollowThreadLocalsExecutorService(executor, namePrefix);
+      } else {
+        executorService = executor;
+      }
+
+      return CloseableExecutorService.wrap(executorService, namePrefix, shutdownTimeout, shutdownTimeUnit);
+    }
+
+    private ThreadFactory buildThreadFactory() {
+      if (Strings.isNullOrEmpty(namePrefix)) { // hack for people who don't have a name
+        if (HAS_WARNED_UNNAMED_THREADFACTORY.compareAndSet(false, true)) {
+          LOG.error("(づ｡◕‿‿◕｡)づ  Your newborn ThreadFactory needs a name!",
+              new RuntimeException("unnamed ThreadFactory"));
+        }
+        return new ThreadFactoryBuilder().setDaemon(daemon)
+            .build();
+      } else {
+        return ThreadFactories.newBuilder(namePrefix)
+            .setDaemon(daemon)
+            .build();
+      }
+    }
+    private BlockingQueue<Runnable> getQueue() {
+      if (queue != null) {
+        return queue;
+      } else if (unbounded) {
+        return new SynchronousQueue<>(fair);
+      } else if (queueSize.isPresent() && queueSize.get() == 0) {
+        return new SynchronousQueue<>(fair);
+      } else if (queueSize.isPresent()) {
+        return new ArrayBlockingQueue<>(queueSize.get(), fair);
+      } else {
+        return new LinkedBlockingQueue<>();
+      }
+    }
+
+    private RejectedExecutionHandler getRejectionPolicy() {
+      if (blockWhenFull) {
+        return new BlockCallerPolicy();
+      } else {
+        return new ThreadPoolExecutor.AbortPolicy();
+      }
+    }
+  }
+
+  private static class BlockCallerPolicy implements RejectedExecutionHandler {
+    @Override
+    public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+      try {
+        // block until there's room
+        executor.getQueue()
+            .put(r);
+      } catch (InterruptedException e) {
+        throw new RejectedExecutionException("Unexpected InterruptedException", e);
+      }
+    }
+  }
+}

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/ThreadContextFollower.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/ThreadContextFollower.java
@@ -1,0 +1,19 @@
+package com.hubspot.slack.client.concurrency;
+
+public interface ThreadContextFollower<T, V> {
+  /**
+   * Get whatever thread local context this follower cares about.
+   */
+  T getContext(String namePrefix);
+
+  /**
+   * Set the context that was retrieved earlier in the current thread.
+   */
+  V setContext(String namePrefix, T item);
+
+  /**
+   * Clear the context after a thread.
+   */
+  default void clearContext(String namePrefix, V item) {
+  }
+}

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/ThreadContextHook.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/ThreadContextHook.java
@@ -1,0 +1,86 @@
+package com.hubspot.slack.client.concurrency;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * A helper to automatically follow threadlocal contexts
+ * across thread boundaries where they make sense.
+ * <p>
+ * Writing a new context hook:
+ * <p>
+ * 1) Create an implementation of the interface {@link ThreadContextFollower}
+ * 2) Create a file in /resources/META-INF/services called "com.hubspot.java.thread.ThreadContextFollower"
+ * 3) Add a line containing the full class name of your implementation.
+ * 4) Profit!
+ * <p>
+ * Adding a new place to thread the context:
+ * <p>
+ * 1) Save ThreadContextHook.Context currentContext = ThreadContextHook.INSTANCE.buildThreadContext(namePrefix) when about to leave
+ * the current thread.
+ * <p>
+ * 2) In the other thread, call ThreadContextHook.INSTANCE.initializeThreadContext(namePrefix, currentContext) to hydreate the
+ * old context in the current thread.
+ */
+public enum ThreadContextHook {
+  INSTANCE;
+
+  private final Collection<ThreadContextFollower> followers;
+
+  ThreadContextHook() {
+    ServiceLoader<ThreadContextFollower> loader = ServiceLoader.load(ThreadContextFollower.class);
+    followers = ImmutableList.copyOf(loader);
+  }
+
+  public Context buildThreadContext(String namePrefix) {
+    IdentityHashMap<ThreadContextFollower, Object> retainedObjects = new IdentityHashMap<>();
+    for (ThreadContextFollower follower : followers) {
+      retainedObjects.put(follower, follower.getContext(namePrefix));
+    }
+    return new Context(Collections.unmodifiableMap(retainedObjects));
+  }
+
+  @SuppressWarnings("unchecked")
+  public Context initializeThreadContext(String namePrefix, Context context) {
+    IdentityHashMap<ThreadContextFollower, Object> initializingObjects = new IdentityHashMap<>();
+    for (ThreadContextFollower follower : followers) {
+      Object followerContext = context.followersContext.get(follower);
+      if (followerContext != null) {
+        initializingObjects.put(follower, follower.setContext(namePrefix, followerContext));
+      }
+    }
+    return new Context(Collections.unmodifiableMap(initializingObjects));
+  }
+
+  @SuppressWarnings("unchecked")
+  public void clearThreadContext(String namePrefix, Context context) {
+    for (ThreadContextFollower follower : followers) {
+      follower.clearContext(namePrefix, context.followersContext.get(follower));
+    }
+  }
+
+  public Context buildThreadContext() {
+    return buildThreadContext(null);
+  }
+
+  public void clearThreadContext(Context context) {
+    clearThreadContext(null, context);
+  }
+
+  public Context initializeThreadContext(Context context) {
+    return initializeThreadContext(null, context);
+  }
+
+  public static class Context {
+    private final Map<ThreadContextFollower, Object> followersContext;
+
+    private Context(Map<ThreadContextFollower, Object> followersContext) {
+      this.followersContext = followersContext;
+    }
+  }
+}

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/ThreadFactories.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/ThreadFactories.java
@@ -1,0 +1,31 @@
+package com.hubspot.slack.client.concurrency;
+
+import java.util.concurrent.ThreadFactory;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+public class ThreadFactories {
+
+  public static ThreadFactoryBuilder newBuilder(String name) {
+    return new ThreadFactoryBuilder()
+        .setNameFormat(name + "-%d")
+        .setUncaughtExceptionHandler(new LoggingUncaughtExceptionHandler());
+  }
+
+  public static ThreadFactory newThreadFactory(String name) {
+    return newBuilder(name)
+        .build();
+  }
+
+  public static ThreadFactory newDaemonThreadFactory(String name) {
+    return newBuilder(name)
+        .setDaemon(true)
+        .build();
+  }
+
+  // prevent instantiation
+  private ThreadFactories() {
+    throw new AssertionError();
+  }
+
+}

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/http/NioHttpClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/http/NioHttpClient.java
@@ -4,9 +4,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import com.google.common.util.concurrent.ListenableFuture;
@@ -18,15 +15,13 @@ import com.hubspot.horizon.HttpRequest;
 import com.hubspot.horizon.HttpRequest.Options;
 import com.hubspot.horizon.HttpResponse;
 import com.hubspot.horizon.internal.AbstractHttpResponse;
+import com.hubspot.slack.client.concurrency.MoreExecutors;
 
 public class NioHttpClient implements Closeable {
-  private static final ExecutorService CALLBACK_EXECUTOR = new ThreadPoolExecutor(
-      0,
-      Integer.MAX_VALUE,
-      60,
-      TimeUnit.SECONDS,
-      new SynchronousQueue<>(false)
-  );
+  private static final ExecutorService CALLBACK_EXECUTOR = MoreExecutors.threadPoolDaemonExecutorBuilder("NioHttpClient-Callback")
+      .setFollowThreadLocals(false)
+      .setUnbounded(true)
+      .build();
 
   private final AsyncHttpClient delegate;
 


### PR DESCRIPTION
By default `thenCompose` executes in the calling thread, which really doesn't work in this case. The trick is to add an unbounded default size zero thread pool to handle the chained call -- we'll spawn a thread to handle the recursing (basically just to wait). In general this pool will idle empty (since min size is 0), and can expand for heavy use. Since we're heavily rate limited, threads won't be an issue here, and we make sure to clean up.

I ported our internal executor wrappers here to ensure that it's closeable and we clean up after ourselves.