### PR TITLE
update label char limit

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionIF.java
@@ -22,8 +22,8 @@ public interface SlackFormOptionIF {
     }
 
     String label = getLabel();
-    if (label.length() > 75) {
-      throw new IllegalStateException("Label cannot exceed 75 chars - '" + label + "'");
+    if (label.length() > 24) {
+      throw new IllegalStateException("Label cannot exceed 24 chars - '" + label + "'");
     }
 
     if (Strings.isNullOrEmpty(getValue())) {


### PR DESCRIPTION
Looks like it's 24 now: https://api.slack.com/dialogs