### PR TITLE
Add open conversation method

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationOpenParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationOpenParamsIF.java
@@ -1,0 +1,37 @@
+package com.hubspot.slack.client.methods.params.conversations;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.google.common.base.Joiner;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ConversationOpenParamsIF {
+  Joiner COMMA_JOINER = Joiner.on(',').skipNulls();
+
+  @JsonProperty("channel")
+  Optional<String> getChannelId();
+
+  @JsonIgnore
+  List<String> getUsers();
+
+  @JsonProperty("users")
+  default String getUsersString() {
+    return COMMA_JOINER.join(getUsers());
+  }
+
+  @Default
+  default boolean getReturnIm() {
+    return true;
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/conversations/ConversationsOpenResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/conversations/ConversationsOpenResponseIF.java
@@ -1,0 +1,15 @@
+package com.hubspot.slack.client.models.response.conversations;
+
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.conversations.Conversation;
+import com.hubspot.slack.client.models.response.SlackResponse;
+
+@Immutable
+@HubSpotStyle
+public interface ConversationsOpenResponseIF extends SlackResponse {
+  @JsonProperty("channel")  // this will actually be either a channel, group, or im depending on what was requested
+  Conversation getConversation();
+}

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClient.java
@@ -19,6 +19,7 @@ import com.hubspot.slack.client.methods.params.chat.ChatUpdateMessageParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationArchiveParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationCreateParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationInviteParams;
+import com.hubspot.slack.client.methods.params.conversations.ConversationOpenParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationUnarchiveParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationsFilter;
 import com.hubspot.slack.client.methods.params.conversations.ConversationsHistoryParams;
@@ -55,6 +56,7 @@ import com.hubspot.slack.client.models.response.conversations.ConversationsArchi
 import com.hubspot.slack.client.models.response.conversations.ConversationsCreateResponse;
 import com.hubspot.slack.client.models.response.conversations.ConversationsInfoResponse;
 import com.hubspot.slack.client.models.response.conversations.ConversationsInviteResponse;
+import com.hubspot.slack.client.models.response.conversations.ConversationsOpenResponse;
 import com.hubspot.slack.client.models.response.conversations.ConversationsUnarchiveResponse;
 import com.hubspot.slack.client.models.response.dialog.DialogOpenResponse;
 import com.hubspot.slack.client.models.response.im.ImOpenResponse;
@@ -108,6 +110,7 @@ public interface SlackClient extends Closeable {
   CompletableFuture<Result<ConversationsArchiveResponse, SlackError>> archiveConversation(ConversationArchiveParams params);
   CompletableFuture<Result<ConversationsInfoResponse, SlackError>> getConversationInfo(ConversationsInfoParams params);
   CompletableFuture<Result<Conversation, SlackError>> getConversationByName(String conversationName, ConversationsFilter conversationsFilter);
+  CompletableFuture<Result<ConversationsOpenResponse, SlackError>> openConversation(ConversationOpenParams params);
 
   // usergroups
   CompletableFuture<Result<UsergroupCreateResponse, SlackError>> createUsergroup(UsergroupCreateParams params);

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
@@ -59,6 +59,7 @@ import com.hubspot.slack.client.methods.params.chat.ChatUpdateMessageParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationArchiveParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationCreateParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationInviteParams;
+import com.hubspot.slack.client.methods.params.conversations.ConversationOpenParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationUnarchiveParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationsFilter;
 import com.hubspot.slack.client.methods.params.conversations.ConversationsHistoryParams;
@@ -102,6 +103,7 @@ import com.hubspot.slack.client.models.response.conversations.ConversationsCreat
 import com.hubspot.slack.client.models.response.conversations.ConversationsHistoryResponse;
 import com.hubspot.slack.client.models.response.conversations.ConversationsInfoResponse;
 import com.hubspot.slack.client.models.response.conversations.ConversationsInviteResponse;
+import com.hubspot.slack.client.models.response.conversations.ConversationsOpenResponse;
 import com.hubspot.slack.client.models.response.conversations.ConversationsUnarchiveResponse;
 import com.hubspot.slack.client.models.response.dialog.DialogOpenResponse;
 import com.hubspot.slack.client.models.response.group.GroupsListResponse;
@@ -614,6 +616,11 @@ public class SlackWebClient implements SlackClient {
                 .build());
           }
         });
+  }
+
+  @Override
+  public CompletableFuture<Result<ConversationsOpenResponse, SlackError>> openConversation(ConversationOpenParams params) {
+    return postSlackCommand(SlackMethods.conversations_open, params, ConversationsOpenResponse.class);
   }
 
   private CompletableFuture<Optional<Conversation>> findConversationByName(String conversationName, ConversationsFilter conversationsFilter) {


### PR DESCRIPTION
This adds support for the [conversation.open](https://api.slack.com/methods/conversations.open) method.

@szabowexler 