### PR TITLE
add support for thumb url

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/AttachmentIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/AttachmentIF.java
@@ -30,6 +30,7 @@ public interface AttachmentIF {
   List<Field> getFields();
   Optional<String> getFooter();
   Optional<String> getFooterIcon();
+  Optional<String> getThumbUrl();
 
 
   @JsonProperty("ts")


### PR DESCRIPTION
Adds support for the `thumb_url` field on attachments https://api.slack.com/docs/message-attachments

@szabowexler 