### PR TITLE
support WTA in OAuthCredentials

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/auth/OAuthCredentialsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/auth/OAuthCredentialsIF.java
@@ -13,10 +13,10 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface OAuthCredentialsIF {
   String getAccessToken();
-  String getScope();
   String getTeamName();
   String getTeamId();
-  String getUserId();
+  Optional<String> getScope();
+  Optional<String> getUserId();
   Optional<BotCredentials> getBot();
   Optional<IncomingWebhook> getIncomingWebhook();
 }


### PR DESCRIPTION
Slack's new [Workspace Token Auth](https://api.slack.com/docs/working-with-workspace-tokens) has a slightly different OAuth contract. Mainly, it doesn't send back the `scope` or `user_id` fields so those need to be optional here.

cc @darcatron 