### PR TITLE
update max char checks

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackDialogFormTextElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackDialogFormTextElement.java
@@ -36,10 +36,6 @@ public abstract class AbstractSlackDialogFormTextElement extends SlackDialogForm
       throw new IllegalStateException("Min length must be <= max length, got " + getMinLength() + ", " + getMaxLength());
     }
 
-    if (getValue().isPresent() && getValue().get().length() > 500) {
-      throw new IllegalStateException("Value cannot exceed 500 chars, got '" + getValue().get() + "'");
-    }
-
     if (getHint().isPresent() && getHint().get().length() > 150) {
       throw new IllegalStateException("Hint cannot exceed 150 chars, got '" + getHint().get() + "'");
     }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextElement.java
@@ -29,5 +29,13 @@ public abstract class AbstractSlackFormTextElement extends AbstractSlackDialogFo
     if (getMaxLength() > 150) {
       throw new IllegalStateException("Form text element cannot have max length > 150 chars, got " + getMaxLength());
     }
+
+    if (getMinLength() > 150) {
+      throw new IllegalStateException("Form text element cannot have min length > 150 chars, got " + getMinLength());
+    }
+
+    if (getValue().isPresent() && getValue().get().length() > 150) {
+      throw new IllegalStateException("Value cannot exceed 150 chars, got '" + getValue().get() + "'");
+    }
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextElement.java
@@ -26,16 +26,16 @@ public abstract class AbstractSlackFormTextElement extends AbstractSlackDialogFo
   public void validate() {
     super.validateBaseTextElementProps();
 
-    if (getMaxLength() > 500) {
-      throw new IllegalStateException("Form text element cannot have max length > 500 chars, got " + getMaxLength());
+    if (getMaxLength() > 150) {
+      throw new IllegalStateException("Form text element cannot have max length > 150 chars, got " + getMaxLength());
     }
 
-    if (getMinLength() > 500) {
-      throw new IllegalStateException("Form text element cannot have min length > 500 chars, got " + getMinLength());
+    if (getMinLength() > 150) {
+      throw new IllegalStateException("Form text element cannot have min length > 150 chars, got " + getMinLength());
     }
 
-    if (getValue().isPresent() && getValue().get().length() > 500) {
-      throw new IllegalStateException("Value cannot exceed 500 chars, got '" + getValue().get() + "'");
+    if (getValue().isPresent() && getValue().get().length() > 150) {
+      throw new IllegalStateException("Value cannot exceed 150 chars, got '" + getValue().get() + "'");
     }
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextElement.java
@@ -26,16 +26,16 @@ public abstract class AbstractSlackFormTextElement extends AbstractSlackDialogFo
   public void validate() {
     super.validateBaseTextElementProps();
 
-    if (getMaxLength() > 150) {
-      throw new IllegalStateException("Form text element cannot have max length > 150 chars, got " + getMaxLength());
+    if (getMaxLength() > 500) {
+      throw new IllegalStateException("Form text element cannot have max length > 500 chars, got " + getMaxLength());
     }
 
-    if (getMinLength() > 150) {
-      throw new IllegalStateException("Form text element cannot have min length > 150 chars, got " + getMinLength());
+    if (getMinLength() > 500) {
+      throw new IllegalStateException("Form text element cannot have min length > 500 chars, got " + getMinLength());
     }
 
-    if (getValue().isPresent() && getValue().get().length() > 150) {
-      throw new IllegalStateException("Value cannot exceed 150 chars, got '" + getValue().get() + "'");
+    if (getValue().isPresent() && getValue().get().length() > 500) {
+      throw new IllegalStateException("Value cannot exceed 500 chars, got '" + getValue().get() + "'");
     }
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextareaElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextareaElement.java
@@ -29,5 +29,13 @@ public abstract class AbstractSlackFormTextareaElement extends AbstractSlackDial
     if (getMaxLength() > 3000) {
       throw new IllegalStateException("Form text area cannot have max length > 3000 chars, got " + getMaxLength());
     }
+
+    if (getMinLength() > 3000) {
+      throw new IllegalStateException("Form text area cannot have min length > 3000 chars, got " + getMinLength());
+    }
+
+    if (getValue().isPresent() && getValue().get().length() > 3000) {
+      throw new IllegalStateException("Value cannot exceed 3000 chars, got '" + getValue().get() + "'");
+    }
   }
 }


### PR DESCRIPTION
`500` is not the default max for both `text` and `textarea` fields. This updates the validation to verify `text` < 150 and `textarea` < 3000. I also threw in the checks for min values

Note: [Slack's documention](https://api.slack.com/dialogs) is inconsistent for `text` values. For max_length, they mention 
> Maximum input length allowed for element. Up to 150 characters. Defaults to 150

and then the docs say

> A default value for this field. Up to 500 characters
for `value`

I left it all as 150 just to be safe. Will do a quick local test to see if `500` works for `text` and update this PR


