### PR TITLE
allow deserialization if 'type' is included in json

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorIF.java
@@ -12,7 +12,7 @@ public interface SlackErrorIF {
 
   @Default
   default SlackErrorType getType() {
-    return SlackErrorType.fromCode(getError());
+    return SlackErrorType.get(getError());
   }
 
   @Parameter String getError();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorType.java
@@ -5,6 +5,8 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.hubspot.slack.client.enums.EnumIndex;
+import com.hubspot.slack.client.enums.UnmappedKeyException;
 
 public enum SlackErrorType {
   ACCOUNT_INACTIVE("account_inactive"),
@@ -82,10 +84,21 @@ public enum SlackErrorType {
     return code;
   }
 
-  private static final ImmutableMap<String, SlackErrorType> INDEX = Maps.uniqueIndex(Arrays.asList(SlackErrorType.values()), SlackErrorType::getCode);
+  public String key() {
+    return name().toLowerCase();
+  }
+
+
+  private static final ImmutableMap<String, SlackErrorType> CODE_INDEX = Maps.uniqueIndex(Arrays.asList(SlackErrorType.values()), SlackErrorType::getCode);
+
+  private static final EnumIndex<String, SlackErrorType> TYPE_INDEX = new EnumIndex<>(SlackErrorType.class, SlackErrorType::key);
 
   @JsonCreator
   public static SlackErrorType fromCode(String code) {
-    return INDEX.getOrDefault(code, SlackErrorType.UNKNOWN);
+    try {
+      return TYPE_INDEX.get(code.toLowerCase());
+    } catch (UnmappedKeyException uke) {
+      return CODE_INDEX.getOrDefault(code.toLowerCase(), SlackErrorType.UNKNOWN);
+    }
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorType.java
@@ -94,7 +94,7 @@ public enum SlackErrorType {
   private static final EnumIndex<String, SlackErrorType> TYPE_INDEX = new EnumIndex<>(SlackErrorType.class, SlackErrorType::key);
 
   @JsonCreator
-  public static SlackErrorType fromCode(String code) {
+  public static SlackErrorType get(String code) {
     try {
       return TYPE_INDEX.get(code.toLowerCase());
     } catch (UnmappedKeyException uke) {


### PR DESCRIPTION
### Problem
`MAPPER.writeValueAsString(SlackError.builder().setError("not_authed").build());` outputs
 ```json
{"type":"NOT_AUTHED","error":"not_authed"}
```

Trying to deserialize that means `fromCode` is called with `code = NOT_AUTHED`. This causes the lookup to default to `SlackErrorType.UNKNOWN`. 🙅 

### Solution
Added an index for the keys. It'll now check that first and if it fails, it'll check the codes and default to unknown nothing is found

Tested locally and it looks good
