### PR TITLE
allow empty text field if attachments are provided

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractChatPostMessageParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractChatPostMessageParams.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.hubspot.immutables.style.HubSpotStyle;
 
 @Immutable
@@ -17,8 +18,7 @@ import com.hubspot.immutables.style.HubSpotStyle;
 public abstract class AbstractChatPostMessageParams implements MessageParams {
   @JsonProperty("channel")
   public abstract String getChannelId();
-
-  public abstract Optional<String> getText();
+  public abstract String getText();
   public abstract Optional<String> getThreadTs();
   public abstract Optional<String> getUsername();
   public abstract Optional<Boolean> getAsUser();
@@ -31,7 +31,7 @@ public abstract class AbstractChatPostMessageParams implements MessageParams {
 
   @Check
   public void check() {
-    Preconditions.checkState(getText().isPresent() || !getAttachments().isEmpty(),
+    Preconditions.checkState(!Strings.isNullOrEmpty(getText()) || !getAttachments().isEmpty(),
         "Must include text if not providing attachments");
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractChatPostMessageParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractChatPostMessageParams.java
@@ -2,11 +2,13 @@ package com.hubspot.slack.client.methods.params.chat;
 
 import java.util.Optional;
 
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.google.common.base.Preconditions;
 import com.hubspot.immutables.style.HubSpotStyle;
 
 @Immutable
@@ -16,7 +18,7 @@ public abstract class AbstractChatPostMessageParams implements MessageParams {
   @JsonProperty("channel")
   public abstract String getChannelId();
 
-  public abstract String getText();
+  public abstract Optional<String> getText();
   public abstract Optional<String> getThreadTs();
   public abstract Optional<String> getUsername();
   public abstract Optional<Boolean> getAsUser();
@@ -26,4 +28,10 @@ public abstract class AbstractChatPostMessageParams implements MessageParams {
   public abstract Optional<Boolean> getUnfurlLinks();
   public abstract Optional<Boolean> getUnfurlMedia();
   public abstract Optional<Boolean> getReplyBroadcast();
+
+  @Check
+  public void check() {
+    Preconditions.checkState(getText().isPresent() || !getAttachments().isEmpty(),
+        "Must include text if not providing attachments");
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractChatPostMessageParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractChatPostMessageParams.java
@@ -18,7 +18,7 @@ import com.hubspot.immutables.style.HubSpotStyle;
 public abstract class AbstractChatPostMessageParams implements MessageParams {
   @JsonProperty("channel")
   public abstract String getChannelId();
-  public abstract String getText();
+  public abstract Optional<String> getText();
   public abstract Optional<String> getThreadTs();
   public abstract Optional<String> getUsername();
   public abstract Optional<Boolean> getAsUser();
@@ -31,7 +31,8 @@ public abstract class AbstractChatPostMessageParams implements MessageParams {
 
   @Check
   public void check() {
-    Preconditions.checkState(!Strings.isNullOrEmpty(getText()) || !getAttachments().isEmpty(),
+    Preconditions.checkState((getText().isPresent() && !Strings.isNullOrEmpty(getText().get())) ||
+            !getAttachments().isEmpty(),
         "Must include text if not providing attachments");
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatPostEphemeralMessageParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatPostEphemeralMessageParamsIF.java
@@ -1,9 +1,11 @@
 package com.hubspot.slack.client.methods.params.chat;
 
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import com.hubspot.immutables.style.HubSpotStyle;
 
 @Immutable
@@ -31,5 +33,11 @@ public interface ChatPostEphemeralMessageParamsIF extends MessageParams {
   @JsonProperty("parse")
   default String getParseMode() {
     return "full";
+  }
+
+  @Check
+  default void check() {
+    Preconditions.checkState(getText().isPresent() || !getAttachments().isEmpty(),
+        "Must include text if not providing attachments");
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatPostEphemeralMessageParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatPostEphemeralMessageParamsIF.java
@@ -38,7 +38,8 @@ public interface ChatPostEphemeralMessageParamsIF extends MessageParams {
 
   @Check
   default void check() {
-    Preconditions.checkState(!Strings.isNullOrEmpty(getText()) || !getAttachments().isEmpty(),
+    Preconditions.checkState((getText().isPresent() && !Strings.isNullOrEmpty(getText().get())) ||
+            !getAttachments().isEmpty(),
         "Must include text if not providing attachments");
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatPostEphemeralMessageParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatPostEphemeralMessageParamsIF.java
@@ -6,6 +6,7 @@ import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.hubspot.immutables.style.HubSpotStyle;
 
 @Immutable
@@ -37,7 +38,7 @@ public interface ChatPostEphemeralMessageParamsIF extends MessageParams {
 
   @Check
   default void check() {
-    Preconditions.checkState(getText().isPresent() || !getAttachments().isEmpty(),
+    Preconditions.checkState(!Strings.isNullOrEmpty(getText()) || !getAttachments().isEmpty(),
         "Must include text if not providing attachments");
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatUpdateMessageParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatUpdateMessageParamsIF.java
@@ -1,11 +1,15 @@
 package com.hubspot.slack.client.methods.params.chat;
 
+import java.util.Optional;
+
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.google.common.base.Preconditions;
 import com.hubspot.immutables.style.HubSpotStyle;
 
 @Immutable
@@ -15,7 +19,7 @@ public interface ChatUpdateMessageParamsIF extends MessageParams {
   @JsonProperty("channel")
   String getChannelId();
 
-  String getText();
+  Optional<String> getText();
   String getTs();
 
   @Default
@@ -27,5 +31,11 @@ public interface ChatUpdateMessageParamsIF extends MessageParams {
   @Default
   default String getParse() {
     return "none";
+  }
+
+  @Check
+  default void check() {
+    Preconditions.checkState(getText().isPresent() || !getAttachments().isEmpty(),
+        "Must include text if not providing attachments");
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatUpdateMessageParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatUpdateMessageParamsIF.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.hubspot.immutables.style.HubSpotStyle;
 
 @Immutable
@@ -22,7 +23,8 @@ public interface ChatUpdateMessageParamsIF extends MessageParams {
   @JsonProperty("channel")
   String getChannelId();
 
-  Optional<String> getText();
+  String getText();
+
   String getTs();
 
   @JsonProperty("as_user")
@@ -41,7 +43,7 @@ public interface ChatUpdateMessageParamsIF extends MessageParams {
 
   @Check
   default void check() {
-    Preconditions.checkState(getText().isPresent() || !getAttachments().isEmpty(),
+    Preconditions.checkState(!Strings.isNullOrEmpty(getText()) || !getAttachments().isEmpty(),
         "Must include text if not providing attachments");
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatUpdateMessageParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatUpdateMessageParamsIF.java
@@ -23,7 +23,7 @@ public interface ChatUpdateMessageParamsIF extends MessageParams {
   @JsonProperty("channel")
   String getChannelId();
 
-  String getText();
+  Optional<String> getText();
 
   String getTs();
 
@@ -43,7 +43,8 @@ public interface ChatUpdateMessageParamsIF extends MessageParams {
 
   @Check
   default void check() {
-    Preconditions.checkState(!Strings.isNullOrEmpty(getText()) || !getAttachments().isEmpty(),
+    Preconditions.checkState((getText().isPresent() && !Strings.isNullOrEmpty(getText().get())) ||
+            !getAttachments().isEmpty(),
         "Must include text if not providing attachments");
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/MessageParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/MessageParams.java
@@ -1,12 +1,12 @@
 package com.hubspot.slack.client.methods.params.chat;
 
 import java.util.List;
-import java.util.Optional;
 
 import com.hubspot.slack.client.methods.interceptor.HasChannel;
 import com.hubspot.slack.client.models.Attachment;
 
 public interface MessageParams extends HasChannel {
-  Optional<String> getText();
+  String getText();
+
   List<Attachment> getAttachments();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/MessageParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/MessageParams.java
@@ -1,11 +1,12 @@
 package com.hubspot.slack.client.methods.params.chat;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.hubspot.slack.client.methods.interceptor.HasChannel;
 import com.hubspot.slack.client.models.Attachment;
 
 public interface MessageParams extends HasChannel {
-  String getText();
+  Optional<String> getText();
   List<Attachment> getAttachments();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/MessageParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/MessageParams.java
@@ -1,12 +1,13 @@
 package com.hubspot.slack.client.methods.params.chat;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.hubspot.slack.client.methods.interceptor.HasChannel;
 import com.hubspot.slack.client.models.Attachment;
 
 public interface MessageParams extends HasChannel {
-  String getText();
+  Optional<String> getText();
 
   List<Attachment> getAttachments();
 }

--- a/slack-base/src/test/java/com/hubspot/slack/client/ReflectionBasedFieldPresenceTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/ReflectionBasedFieldPresenceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -27,7 +26,7 @@ class ReflectionBasedFieldPresenceTest {
   private static final Boolean DEFAULT_BOOLEAN = false;
   private static final String DEFAULT_STRING = "default";
   private static final Optional<String> DEFAULT_OPTIONAL_STRING = Optional.of("defaultOptional");
-  private static final List<String> OPTIONAL_STRING_METHODS_TO_BUILD = Collections.singletonList("setText");
+  private static final Set<String> OPTIONAL_STRING_METHODS_TO_BUILD = Collections.singleton("setText");
 
   private static final Reflections SLACK_CLIENT_REFLECTOR = new Reflections("com.hubspot.slack.client");
 

--- a/slack-base/src/test/java/com/hubspot/slack/client/methods/params/chat/MessageParamsTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/methods/params/chat/MessageParamsTest.java
@@ -1,0 +1,89 @@
+package com.hubspot.slack.client.methods.params.chat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.junit.Test;
+
+import com.hubspot.slack.client.models.Attachment;
+
+public class MessageParamsTest {
+
+  @Test
+  public void itBuildsWithAttachmentsAndNoText() {
+    ChatPostEphemeralMessageParams.builder()
+        .setChannelId("testChannelId")
+        .setUserToSendTo("testUserId")
+        .addAttachments(Attachment.builder().build())
+        .build();
+
+    ChatPostMessageParams.builder()
+        .setChannelId("testChannelId")
+        .addAttachments(Attachment.builder().build())
+        .build();
+
+    ChatUpdateMessageParams.builder()
+        .setTs("testTs")
+        .setChannelId("testChannelId")
+        .addAttachments(Attachment.builder().build())
+        .build();
+  }
+
+  @Test
+  public void itBuildsWithTextAndNoAttachments() {
+    ChatPostEphemeralMessageParams.builder()
+        .setChannelId("testChannelId")
+        .setUserToSendTo("testUserId")
+        .setText("testText")
+        .build();
+
+    ChatPostMessageParams.builder()
+        .setChannelId("testChannelId")
+        .setText("testText")
+        .build();
+
+    ChatUpdateMessageParams.builder()
+        .setTs("testTs")
+        .setChannelId("testChannelId")
+        .setText("testText")
+        .build();
+  }
+
+  @Test
+  public void itFailsToBuildWithoutTextOrAttachments() {
+    boolean success = true;
+
+    try {
+      ChatPostEphemeralMessageParams.builder()
+          .setChannelId("testChannelId")
+          .setUserToSendTo("testUserId")
+          .build();
+      success = false;
+    } catch (IllegalStateException ise) {
+      assertThat(ise.getMessage()).contains("Must include text if not providing attachments");
+    }
+
+    try {
+      ChatPostMessageParams.builder()
+          .setChannelId("testChannelId")
+          .build();
+      success = false;
+    } catch (IllegalStateException ise2) {
+      assertThat(ise2.getMessage()).contains("Must include text if not providing attachments");
+    }
+
+    try {
+      ChatUpdateMessageParams.builder()
+          .setTs("testTs")
+          .setChannelId("testChannelId")
+          .build();
+      success = false;
+    } catch (IllegalStateException ise3) {
+      assertThat(ise3.getMessage()).contains("Must include text if not providing attachments");
+    }
+
+    if (!success) {
+      fail("Should have thrown an error for MessageParam built without text or attachments!");
+    }
+  }
+}


### PR DESCRIPTION
Resolves: https://github.com/HubSpot/slack-client/issues/21

Tested locally and the functionality works. 

I tried having the check within the parent `MessageParams` but I got test failures like:
```
pojosDoDeserializeHasChannelsWithChannelField[class com.hubspot.slack.client.methods.params.chat.ChatUpdateMessageParams](com.hubspot.slack.client.HasChannelDeserializerTest)  Time elapsed: 0.002 sec  <<< ERROR!
java.lang.reflect.InvocationTargetException
```

The current build for this is causing similar problems. It's hitting the `@Check` and erroring on the test

Any thoughts on this @szabowexler ?