### PR TITLE
Added include_locale flag to UserInfoParamsIF and added optional loca…

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/users/UsersInfoParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/users/UsersInfoParamsIF.java
@@ -1,5 +1,7 @@
 package com.hubspot.slack.client.methods.params.users;
 
+import java.util.Optional;
+
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Parameter;
 
@@ -14,4 +16,9 @@ public interface UsersInfoParamsIF extends HasUser {
   @Parameter
   @JsonProperty("user")
   String getUserId();
+
+  @JsonProperty("include_local")
+  default boolean getIncludeLocale() {
+    return false;
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/users/SlackUserIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/users/SlackUserIF.java
@@ -39,6 +39,9 @@ public interface SlackUserIF extends SlackUserCore {
   @JsonProperty("updated")
   Optional<Integer> getRawUpdated();
 
+  @JsonProperty("locale")
+  Optional<String> getLocale();
+
   @Derived
   default Optional<Long> getUpdatedAt() {
     return getRawUpdated().map(updated -> updated * 1000L);


### PR DESCRIPTION
Added an optional include_locale flag on UserParamsIF and the corresponding optional on SlackUser to allow us to use the optional include_local flag on the slack API (see https://api.slack.com/methods/users.info)