### PR TITLE
add support for top level message

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/TopLevelMessageResponseType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/TopLevelMessageResponseType.java
@@ -1,0 +1,7 @@
+package com.hubspot.slack.client.models;
+
+public enum TopLevelMessageResponseType {
+  EPHEMERAL,
+  IN_CHANNEL,
+  ;
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackDialogFormTextElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackDialogFormTextElement.java
@@ -23,6 +23,7 @@ public abstract class AbstractSlackDialogFormTextElement extends SlackDialogForm
   public abstract Optional<String> getValue();
 
   protected void validateBaseTextElementProps() {
+
     super.validateBaseElementProperties();
     if (getMinLength() < 0) {
       throw new IllegalStateException("Min length cannot be negative, got " + getMinLength());

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/TopLevelMessageInteractionResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/TopLevelMessageInteractionResponseIF.java
@@ -1,7 +1,9 @@
 package com.hubspot.slack.client.models.interaction;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
@@ -24,7 +26,14 @@ public interface TopLevelMessageInteractionResponseIF {
     return false;
   }
 
-  String getText();
+  Optional<String> getText();
 
   List<Attachment> getAttachments();
+
+  @Check
+  default void check() {
+    if (!getText().isPresent() && getAttachments().isEmpty()) {
+      throw new IllegalStateException("Must supply either text or attachments");
+    }
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/TopLevelMessageInteractionResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/TopLevelMessageInteractionResponseIF.java
@@ -1,0 +1,25 @@
+package com.hubspot.slack.client.models.interaction;
+
+import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.TopLevelMessageResponseType;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface TopLevelMessageInteractionResponseIF {
+  TopLevelMessageResponseType getResponseType();
+
+  boolean getReplaceOriginal();
+
+  @Default
+  default boolean getDeleteOriginal() {
+    return false;
+  }
+
+  String getText();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/TopLevelMessageInteractionResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/TopLevelMessageInteractionResponseIF.java
@@ -1,11 +1,14 @@
 package com.hubspot.slack.client.models.interaction;
 
+import java.util.List;
+
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.Attachment;
 import com.hubspot.slack.client.models.TopLevelMessageResponseType;
 
 @Immutable
@@ -22,4 +25,6 @@ public interface TopLevelMessageInteractionResponseIF {
   }
 
   String getText();
+
+  List<Attachment> getAttachments();
 }


### PR DESCRIPTION
This allows users to respond to interactions right away with a [top level slack message](https://api.slack.com/docs/interactive-message-field-guide#message)

This is most useful for message interactions where you want to replace or delete the original message based on an interaction

Tested this locally

cc @szabowexler 
