### PR TITLE
Add basic support for uploading files

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/files/FilesUploadParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/files/FilesUploadParamsIF.java
@@ -1,0 +1,34 @@
+package com.hubspot.slack.client.methods.params.files;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.immutables.value.Value.Check;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface FilesUploadParamsIF {
+  List<String> getChannels();
+  Optional<String> getContent();
+  Optional<String> getFilename();
+  Optional<String> getInitialComment();
+  Optional<String> getThreadTs();
+  Optional<String> getTitle();
+
+  @Check
+  @JsonIgnore
+  default void hasContent() {
+    if (!getContent().isPresent()) {
+      // We don't support multipart/form-data yet, so content has to be present.
+      // But we will eventually, so the signature should have content as Optional
+      throw new IllegalStateException("Must provide some content to upload a file");
+    }
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
@@ -1,0 +1,65 @@
+package com.hubspot.slack.client.models.files;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+
+@JsonTypeInfo(
+    use = Id.NAME,
+    include = As.EXISTING_PROPERTY,
+    property = "filetype"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = SlackTextFile.class, name = "text"),
+    @JsonSubTypes.Type(value = SlackGifFile.class, name = "gif")
+})
+public interface SlackFile {
+  String getId();
+  @JsonProperty("created")
+  long getCreatedEpochSeconds();
+  @JsonProperty("timestamp")
+  long getTimestampEpochSeconds();
+  String getName();
+  String getTitle();
+  String getMimetype();
+  SlackFileTypes getFiletype();
+  String getPrettyType();
+
+  @JsonProperty("user")
+  String getUserId();
+
+  boolean isEditable();
+  long getSize();
+
+  String getMode();
+  @JsonProperty("is_external")
+  boolean isExternal();
+  @JsonProperty("is_public")
+  boolean isPublic();
+  boolean isPublicUrlShared();
+  boolean getDisplayAsBot();
+  String getUsername();
+  String getUrlPrivate();
+  String getUrlPrivateDownload();
+
+  String getPermalink();
+  String getPermalinkPublic();
+
+  int getCommentsCount();
+  @JsonProperty("is_starred")
+  boolean isStarred();
+
+  @JsonProperty("channels")
+  List<String> getChannelIds();
+  @JsonProperty("groups")
+  List<String> getGroupIds();
+  @JsonProperty("ims")
+  List<String> getImIds();
+
+  @JsonProperty("has_rich_preview")
+  boolean hasRichPreview();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
@@ -59,7 +59,4 @@ public interface SlackFile {
   List<String> getGroupIds();
   @JsonProperty("ims")
   List<String> getImIds();
-
-  @JsonProperty("has_rich_preview")
-  boolean hasRichPreview();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileTypes.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileTypes.java
@@ -1,0 +1,31 @@
+package com.hubspot.slack.client.models.files;
+
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum SlackFileTypes {
+  TEXT("text"),
+  GIF("gif"),
+  ;
+
+  final String type;
+
+  SlackFileTypes(String type) {
+    this.type = type;
+  }
+
+  @JsonValue
+  public String getType() {
+    return type;
+  }
+
+  @JsonCreator
+  public static SlackFileTypes parse(String field) {
+    return Stream.of(values())
+        .filter(val -> val.getType().equalsIgnoreCase(field))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(field + " doesn't match any known slack file type"));
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackGifFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackGifFileIF.java
@@ -3,6 +3,7 @@ package com.hubspot.slack.client.models.files;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -16,4 +17,7 @@ public interface SlackGifFileIF extends SlackImageFile {
   default SlackFileTypes getFiletype() {
     return SlackFileTypes.GIF;
   }
+
+  @JsonProperty("has_rich_preview")
+  boolean hasRichPreview();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackGifFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackGifFileIF.java
@@ -1,0 +1,19 @@
+package com.hubspot.slack.client.models.files;
+
+import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface SlackGifFileIF extends SlackImageFile {
+  @Default
+  @Override
+  default SlackFileTypes getFiletype() {
+    return SlackFileTypes.GIF;
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackGifFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackGifFileIF.java
@@ -3,7 +3,6 @@ package com.hubspot.slack.client.models.files;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -17,7 +16,4 @@ public interface SlackGifFileIF extends SlackImageFile {
   default SlackFileTypes getFiletype() {
     return SlackFileTypes.GIF;
   }
-
-  @JsonProperty("has_rich_preview")
-  boolean hasRichPreview();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackImageFile.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackImageFile.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public interface SlackImageFile extends SlackFile {
-
   @JsonProperty("thumb_64")
   Optional<String> getThumb64Url();
   @JsonProperty("thumb_80")
@@ -32,4 +31,7 @@ public interface SlackImageFile extends SlackFile {
   Optional<Integer> getOriginalWidth();
   @JsonProperty("original_h")
   Optional<Integer> getOriginalHeight();
+
+  @JsonProperty("has_rich_preview")
+  boolean hasRichPreview();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackImageFile.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackImageFile.java
@@ -1,0 +1,35 @@
+package com.hubspot.slack.client.models.files;
+
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public interface SlackImageFile extends SlackFile {
+
+  @JsonProperty("thumb_64")
+  Optional<String> getThumb64Url();
+  @JsonProperty("thumb_80")
+  Optional<String> getThumb80Url();
+  @JsonProperty("thumb_160")
+  Optional<String> getThumb160Url();
+
+  @JsonProperty("thumb_360")
+  Optional<String> getThumb360Url();
+  @JsonProperty("thumb_360_w")
+  Optional<Integer> getThumb360Width();
+  @JsonProperty("thumb_360_h")
+  Optional<Integer> getThumb360Height();
+
+  @JsonProperty("thumb_480")
+  Optional<String> getThumb480Url();
+  @JsonProperty("thumb_480_w")
+  Optional<Integer> getThumb480Width();
+  @JsonProperty("thumb_480_h")
+  Optional<Integer> getThumb480Height();
+
+  Optional<Integer> getImageExifRotation();
+  @JsonProperty("original_w")
+  Optional<Integer> getOriginalWidth();
+  @JsonProperty("original_h")
+  Optional<Integer> getOriginalHeight();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackTextFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackTextFileIF.java
@@ -1,0 +1,29 @@
+package com.hubspot.slack.client.models.files;
+
+import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface SlackTextFileIF extends SlackFile {
+  @Default
+  @Override
+  default SlackFileTypes getFiletype() {
+    return SlackFileTypes.TEXT;
+  }
+
+  String getEditLink();
+  String getPreview();
+  String getPreviewHighlight();
+  String getLines();
+  String getLinesMore();
+
+  @JsonProperty("preview_is_truncated")
+  boolean isPreviewTruncated();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/files/FilesUploadResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/files/FilesUploadResponseIF.java
@@ -1,0 +1,16 @@
+package com.hubspot.slack.client.models.response.files;
+
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.files.SlackFile;
+import com.hubspot.slack.client.models.response.SlackResponse;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface FilesUploadResponseIF extends SlackResponse {
+  SlackFile getFile();
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/TestMappers.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/TestMappers.java
@@ -1,0 +1,12 @@
+package com.hubspot.slack.client;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+
+public final class TestMappers {
+  private TestMappers() {}
+  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+      .registerModule(new Jdk8Module())
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/response/SlackFileUploadResponseTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/response/SlackFileUploadResponseTest.java
@@ -1,0 +1,24 @@
+package com.hubspot.slack.client.models.response;
+
+import org.junit.Test;
+
+import com.hubspot.slack.client.TestMappers;
+import com.hubspot.slack.client.models.JsonLoader;
+import com.hubspot.slack.client.models.response.files.FilesUploadResponse;
+
+public class SlackFileUploadResponseTest {
+  @Test
+  public void itDoesDeserializeFilesUploadResponseForContentField() throws Exception {
+    String rawJson = JsonLoader.loadJsonFromFile("file_upload_content_param_result.json");
+
+    FilesUploadResponse response = TestMappers.OBJECT_MAPPER.readValue(rawJson, FilesUploadResponse.class);
+  }
+
+  @Test
+  public void itDoesDeserializeFilesUploadResponseForImage() throws Exception {
+    String rawJson = JsonLoader.loadJsonFromFile("file_upload_gif_result.json");
+
+    FilesUploadResponse response = TestMappers.OBJECT_MAPPER.readValue(rawJson, FilesUploadResponse.class);
+    response.getFile();
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/response/SlackResponseTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/response/SlackResponseTest.java
@@ -4,16 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.hubspot.slack.client.TestMappers;
 import com.hubspot.slack.client.models.response.users.UsersInfoResponse;
 
 public class SlackResponseTest {
-
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-      .registerModule(new Jdk8Module())
-      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   private static final String ERROR_RESPONSE = "{\n" +
       "    \"ok\": false,\n" +
@@ -48,7 +42,7 @@ public class SlackResponseTest {
 
   @Test
   public void itDoesDeserializeErrorResponse() throws Exception {
-    SlackErrorResponse errorResponse = OBJECT_MAPPER.readValue(ERROR_RESPONSE, SlackErrorResponse.class);
+    SlackErrorResponse errorResponse = TestMappers.OBJECT_MAPPER.readValue(ERROR_RESPONSE, SlackErrorResponse.class);
 
     assertThat(errorResponse.isOk()).isFalse();
     assertThat(errorResponse.getError().getError()).isNotEmpty();
@@ -57,7 +51,7 @@ public class SlackResponseTest {
 
   @Test
   public void itDoesDeserializeUserResponse() throws Exception {
-    UsersInfoResponse userResponse = OBJECT_MAPPER.readValue(USER_RESPONSE, UsersInfoResponse.class);
+    UsersInfoResponse userResponse = TestMappers.OBJECT_MAPPER.readValue(USER_RESPONSE, UsersInfoResponse.class);
 
     assertThat(userResponse.isOk()).isTrue();
     assertThat(userResponse.getUser().getUsername()).isPresent();

--- a/slack-base/src/test/resources/file_upload_content_param_result.json
+++ b/slack-base/src/test/resources/file_upload_content_param_result.json
@@ -1,0 +1,55 @@
+{
+  "ok": true,
+  "file": {
+    "id": "F0TD0GUTS",
+    "created": 1532294750,
+    "timestamp": 1532294750,
+    "name": "-.txt",
+    "title": "Untitled",
+    "mimetype": "text/plain",
+    "filetype": "text",
+    "pretty_type": "Plain Text",
+    "user": "U0L4B9NSU",
+    "editable": true,
+    "size": 11,
+    "mode": "snippet",
+    "is_external": false,
+    "external_type": "",
+    "is_public": true,
+    "public_url_shared": false,
+    "display_as_bot": false,
+    "username": "",
+    "url_private": "https://.../.txt",
+    "url_private_download": "https://...download/-.txt",
+    "permalink": "https://.../.txt",
+    "permalink_public": "https://.../.txt",
+    "edit_link": "https://.../.txt/edit",
+    "preview": "launch plan",
+    "preview_highlight": "<div class=\"CodeMirror cm-s-default CodeMirrorServer\" oncopy=\"if(event.clipboardData){event.clipboardData.setData('text/plain',window.getSelection().toString().replace(/\\u200b/g,''));event.preventDefault();event.stopPropagation();}\">\n<div class=\"CodeMirror-code\">\n<div><pre>launch plan</pre></div>\n</div>\n</div>\n",
+    "lines": 1,
+    "lines_more": 0,
+    "preview_is_truncated": false,
+    "comments_count": 0,
+    "is_starred": false,
+    "shares": {
+      "public": {
+        "C061EG9SL": [
+          {
+            "reply_users": [],
+            "reply_users_count": 0,
+            "reply_count": 0,
+            "ts": "1532294750.000001",
+            "channel_name": "general",
+            "team_id": "T061EG9R6"
+          }
+        ]
+      }
+    },
+    "channels": [
+      "C061EG9SL"
+    ],
+    "groups": [],
+    "ims": [],
+    "has_rich_preview": false
+  }
+}

--- a/slack-base/src/test/resources/file_upload_gif_result.json
+++ b/slack-base/src/test/resources/file_upload_gif_result.json
@@ -1,0 +1,59 @@
+{
+  "ok": true,
+  "file": {
+    "id": "F0TD00400",
+    "created": 1532293501,
+    "timestamp": 1532293501,
+    "name": "dramacat.gif",
+    "title": "dramacat",
+    "mimetype": "image/jpeg",
+    "filetype": "gif",
+    "pretty_type": "JPEG",
+    "user": "U0L4B9NSU",
+    "editable": false,
+    "size": 43518,
+    "mode": "hosted",
+    "is_external": false,
+    "external_type": "",
+    "is_public": false,
+    "public_url_shared": false,
+    "display_as_bot": false,
+    "username": "",
+    "url_private": "https://.../dramacat.gif",
+    "url_private_download": "https://.../dramacat.gif",
+    "thumb_64": "https://.../dramacat_64.gif",
+    "thumb_80": "https://.../dramacat_80.gif",
+    "thumb_360": "https://.../dramacat_360.gif",
+    "thumb_360_w": 360,
+    "thumb_360_h": 250,
+    "thumb_480": "https://.../dramacat_480.gif",
+    "thumb_480_w": 480,
+    "thumb_480_h": 334,
+    "thumb_160": "https://.../dramacat_160.gif",
+    "image_exif_rotation": 1,
+    "original_w": 526,
+    "original_h": 366,
+    "permalink": "https://.../dramacat.gif",
+    "permalink_public": "https://.../More-Path-Components",
+    "comments_count": 0,
+    "is_starred": false,
+    "shares": {
+      "private": {
+        "D0L4B9P0Q": [
+          {
+            "reply_users": [],
+            "reply_users_count": 0,
+            "reply_count": 0,
+            "ts": "1532293503.000001"
+          }
+        ]
+      }
+    },
+    "channels": [],
+    "groups": [],
+    "ims": [
+      "D0L4B9P0Q"
+    ],
+    "has_rich_preview": false
+  }
+}

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClient.java
@@ -27,6 +27,7 @@ import com.hubspot.slack.client.methods.params.conversations.ConversationsInfoPa
 import com.hubspot.slack.client.methods.params.conversations.ConversationsListParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationsUserParams;
 import com.hubspot.slack.client.methods.params.dialog.DialogOpenParams;
+import com.hubspot.slack.client.methods.params.files.FilesUploadParams;
 import com.hubspot.slack.client.methods.params.group.GroupsListParams;
 import com.hubspot.slack.client.methods.params.im.ImOpenParams;
 import com.hubspot.slack.client.methods.params.reactions.ReactionsAddParams;
@@ -60,6 +61,7 @@ import com.hubspot.slack.client.models.response.conversations.ConversationsInvit
 import com.hubspot.slack.client.models.response.conversations.ConversationsOpenResponse;
 import com.hubspot.slack.client.models.response.conversations.ConversationsUnarchiveResponse;
 import com.hubspot.slack.client.models.response.dialog.DialogOpenResponse;
+import com.hubspot.slack.client.models.response.files.FilesUploadResponse;
 import com.hubspot.slack.client.models.response.im.ImOpenResponse;
 import com.hubspot.slack.client.models.response.reactions.AddReactionResponse;
 import com.hubspot.slack.client.models.response.search.SearchMessageResponse;
@@ -129,6 +131,9 @@ public interface SlackClient extends Closeable {
 
   // reactions
   CompletableFuture<Result<AddReactionResponse, SlackError>> addReaction(ReactionsAddParams param);
+
+  // files
+  CompletableFuture<Result<FilesUploadResponse, SlackError>> uploadFile(FilesUploadParams params);
 
   // extension
   <T extends SlackResponse> CompletableFuture<Result<T, SlackError>> postSlackCommand(

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
@@ -67,6 +67,7 @@ import com.hubspot.slack.client.methods.params.conversations.ConversationsInfoPa
 import com.hubspot.slack.client.methods.params.conversations.ConversationsListParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationsUserParams;
 import com.hubspot.slack.client.methods.params.dialog.DialogOpenParams;
+import com.hubspot.slack.client.methods.params.files.FilesUploadParams;
 import com.hubspot.slack.client.methods.params.group.GroupsListParams;
 import com.hubspot.slack.client.methods.params.im.ImOpenParams;
 import com.hubspot.slack.client.methods.params.reactions.ReactionsAddParams;
@@ -107,6 +108,7 @@ import com.hubspot.slack.client.models.response.conversations.ConversationsInvit
 import com.hubspot.slack.client.models.response.conversations.ConversationsOpenResponse;
 import com.hubspot.slack.client.models.response.conversations.ConversationsUnarchiveResponse;
 import com.hubspot.slack.client.models.response.dialog.DialogOpenResponse;
+import com.hubspot.slack.client.models.response.files.FilesUploadResponse;
 import com.hubspot.slack.client.models.response.group.GroupsListResponse;
 import com.hubspot.slack.client.models.response.im.ImOpenResponse;
 import com.hubspot.slack.client.models.response.reactions.AddReactionResponse;
@@ -771,6 +773,11 @@ public class SlackWebClient implements SlackClient {
   @Override
   public CompletableFuture<Result<AddReactionResponse, SlackError>> addReaction(ReactionsAddParams params) {
     return postSlackCommand(SlackMethods.reactions_add, params, AddReactionResponse.class);
+  }
+
+  @Override
+  public CompletableFuture<Result<FilesUploadResponse, SlackError>> uploadFile(FilesUploadParams params) {
+    return postSlackCommand(SlackMethods.files_upload, params, FilesUploadResponse.class);
   }
 
   @Override


### PR DESCRIPTION
Per the description, adds support for calling [`files.upload`](https://api.slack.com/methods/files.upload). This isn't complete (no support for `mime/multipart` right now), but allows a user to upload a block of text (i.e. creating a snippet). The class structure here is permissive, and makes it easy to add additional filetype wrappers (I've added image based (gif) file handles as well as the core text to make the eventual extension to mime simpler). Once I've tested it in the wild I'll merge.

@darcatron 