### PR TITLE
Add support for sharing file publically

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/files/FilesSharedPublicUrlParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/files/FilesSharedPublicUrlParamsIF.java
@@ -1,0 +1,18 @@
+package com.hubspot.slack.client.methods.params.files;
+
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Parameter;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface FilesSharedPublicUrlParamsIF {
+  @Parameter
+  @JsonProperty("file")
+  String getFileId();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/files/FilesSharedPublicUrlResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/files/FilesSharedPublicUrlResponseIF.java
@@ -1,0 +1,16 @@
+package com.hubspot.slack.client.models.response.files;
+
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.files.SlackFile;
+import com.hubspot.slack.client.models.response.SlackResponse;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface FilesSharedPublicUrlResponseIF extends SlackResponse {
+  SlackFile getFile();
+}

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClient.java
@@ -27,6 +27,7 @@ import com.hubspot.slack.client.methods.params.conversations.ConversationsInfoPa
 import com.hubspot.slack.client.methods.params.conversations.ConversationsListParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationsUserParams;
 import com.hubspot.slack.client.methods.params.dialog.DialogOpenParams;
+import com.hubspot.slack.client.methods.params.files.FilesSharedPublicUrlParams;
 import com.hubspot.slack.client.methods.params.files.FilesUploadParams;
 import com.hubspot.slack.client.methods.params.group.GroupsListParams;
 import com.hubspot.slack.client.methods.params.im.ImOpenParams;
@@ -62,6 +63,7 @@ import com.hubspot.slack.client.models.response.conversations.ConversationsInvit
 import com.hubspot.slack.client.models.response.conversations.ConversationsOpenResponse;
 import com.hubspot.slack.client.models.response.conversations.ConversationsUnarchiveResponse;
 import com.hubspot.slack.client.models.response.dialog.DialogOpenResponse;
+import com.hubspot.slack.client.models.response.files.FilesSharedPublicUrlResponse;
 import com.hubspot.slack.client.models.response.files.FilesUploadResponse;
 import com.hubspot.slack.client.models.response.im.ImOpenResponse;
 import com.hubspot.slack.client.models.response.reactions.AddReactionResponse;
@@ -137,6 +139,7 @@ public interface SlackClient extends Closeable {
 
   // files
   CompletableFuture<Result<FilesUploadResponse, SlackError>> uploadFile(FilesUploadParams params);
+  CompletableFuture<Result<FilesSharedPublicUrlResponse, SlackError>> shareFilePublically(FilesSharedPublicUrlParams params);
 
   // extension
   <T extends SlackResponse> CompletableFuture<Result<T, SlackError>> postSlackCommand(

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
@@ -67,6 +67,7 @@ import com.hubspot.slack.client.methods.params.conversations.ConversationsInfoPa
 import com.hubspot.slack.client.methods.params.conversations.ConversationsListParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationsUserParams;
 import com.hubspot.slack.client.methods.params.dialog.DialogOpenParams;
+import com.hubspot.slack.client.methods.params.files.FilesSharedPublicUrlParams;
 import com.hubspot.slack.client.methods.params.files.FilesUploadParams;
 import com.hubspot.slack.client.methods.params.group.GroupsListParams;
 import com.hubspot.slack.client.methods.params.im.ImOpenParams;
@@ -108,6 +109,7 @@ import com.hubspot.slack.client.models.response.conversations.ConversationsInvit
 import com.hubspot.slack.client.models.response.conversations.ConversationsOpenResponse;
 import com.hubspot.slack.client.models.response.conversations.ConversationsUnarchiveResponse;
 import com.hubspot.slack.client.models.response.dialog.DialogOpenResponse;
+import com.hubspot.slack.client.models.response.files.FilesSharedPublicUrlResponse;
 import com.hubspot.slack.client.models.response.files.FilesUploadResponse;
 import com.hubspot.slack.client.models.response.group.GroupsListResponse;
 import com.hubspot.slack.client.models.response.im.ImOpenResponse;
@@ -783,6 +785,11 @@ public class SlackWebClient implements SlackClient {
   @Override
   public CompletableFuture<Result<FilesUploadResponse, SlackError>> uploadFile(FilesUploadParams params) {
     return postSlackCommand(SlackMethods.files_upload, params, FilesUploadResponse.class);
+  }
+
+  @Override
+  public CompletableFuture<Result<FilesSharedPublicUrlResponse, SlackError>> shareFilePublically(FilesSharedPublicUrlParams params) {
+    return postSlackCommand(SlackMethods.files_sharedPublicURL, params, FilesSharedPublicUrlResponse.class);
   }
 
   @Override


### PR DESCRIPTION
What it says on the tin. Adds support for [`files.sharedPublicURL`](https://api.slack.com/methods/files.sharedPublicURL). Since file uploads are (by default) not shared, you need to be able to share them with the world to actually send links to folks.