### PR TITLE
Examine headers for potential auth headers, and auto-redact them

### DIFF
--- a/slack-java-client/pom.xml
+++ b/slack-java-client/pom.xml
@@ -72,5 +72,15 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
+
+    <!-- test deps -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/interceptors/http/HttpFormatter.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/interceptors/http/HttpFormatter.java
@@ -14,7 +14,7 @@ public class HttpFormatter {
     builder.append(request.getMethod()).append(" ").append(request.getUrl()).append("\n");
 
     builder.append("------------------------------------------\n");
-    request.getHeaders().forEach(header -> builder.append(header.getName()).append(" = ").append(header.getValue()).append("\n"));
+    request.getHeaders().forEach(header -> builder.append(safeHeaderString(header.getName(), header.getValue())));
     builder.append("------------------------------------------\n");
 
     byte[] body = request.getBody(ObjectMapperUtils.mapper());
@@ -30,6 +30,37 @@ public class HttpFormatter {
     }
 
     return builder.toString();
+  }
+
+  static String safeHeaderString(
+      String headerName,
+      String headerValue
+  ) {
+    if (isAuthHeader(headerName)) {
+      String[] authParts = headerValue.split(" ");
+      if (authParts.length == 2) {
+        String token = authParts[1];
+        String elidedToken;
+        if (token.length() < 9) {
+          elidedToken = token.charAt(0) + "..." + token.charAt(token.length() - 1);
+        } else {
+          elidedToken = token.substring(0, 3) + "..." + token.substring(token.length() - 4, token.length());
+        }
+
+        return headerName + " = " + authParts[0] + " " + elidedToken;
+      }
+    }
+
+    return headerName + " = " + headerValue + "\n";
+  }
+
+  private static boolean isAuthHeader(String headerName) {
+    String lowercaseHeaderName = headerName.toLowerCase();
+    if (lowercaseHeaderName.contains("auth")) {
+      return true;
+    }
+
+    return false;
   }
 
   static String formatResponse(HttpResponse response) {

--- a/slack-java-client/src/test/java/com/hubspot/slack/client/interceptors/http/HttpFormatterTest.java
+++ b/slack-java-client/src/test/java/com/hubspot/slack/client/interceptors/http/HttpFormatterTest.java
@@ -1,0 +1,37 @@
+package com.hubspot.slack.client.interceptors.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class HttpFormatterTest {
+  @Test
+  public void itDoesElideAuthTokens() throws Exception {
+    assertThat(
+        HttpFormatter.safeHeaderString(
+            "Authorization",
+            "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuYXV0aDAuY29tLyIsImF1ZCI6Imh0dHBzOi8vYXBpLmV4YW1wbGUuY29tL2NhbGFuZGFyL3YxLyIsInN1YiI6InVzcl8xMjMiLCJpYXQiOjE0NTg3ODU3OTYsImV4cCI6MTQ1ODg3MjE5Nn0.CA7eaHjIHz5NxeIJoFK9krqaeZrPLwmMmgI_XiQiIkQ"
+        )
+    )
+        .describedAs("If it looks like a bearer HTTP auth token, we should redact the full token, providing just a fingerprint")
+        .contains("Authorization = Bearer eyJ...iIkQ");
+
+    assertThat(
+        HttpFormatter.safeHeaderString(
+            "Authorization",
+            "Bearer eiQiIkQ"
+        )
+    )
+        .describedAs("If it looks like a short HTTP auth token, we should redact the full token, providing just a fingerprint")
+        .contains("Authorization = Bearer e...Q");
+
+    assertThat(
+        HttpFormatter.safeHeaderString(
+            "Authorization",
+            "Basic YWxhZGRpbjpvcGVuc2VzYW1l"
+        )
+    )
+        .describedAs("If it looks like a basic HTTP auth token, we should redact the full token, providing just a fingerprint")
+        .contains("Authorization = Basic YWx...YW1l");
+  }
+}


### PR DESCRIPTION
We should carefully never print full auth tokens if we can infer that that's what we're handling.