### PR TITLE
Add slack event json view

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventView.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventView.java
@@ -1,7 +1,5 @@
 package com.hubspot.slack.client.models.events;
 
-import com.fasterxml.jackson.annotation.JsonView;
-
 public interface SlackEventView {
-  public static interface Internal {}
+  interface Internal {}
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventView.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventView.java
@@ -1,0 +1,7 @@
+package com.hubspot.slack.client.models.events;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+public interface SlackEventView {
+  public static interface Internal {}
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventWrapperIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventWrapperIF.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.immutables.value.Value.Immutable;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -12,6 +13,7 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 public interface SlackEventWrapperIF<T extends SlackEvent> {
+  @JsonView(SlackEventView.Internal.class)
   String getToken();
   String getTeamId();
   SlackEventType getType();


### PR DESCRIPTION
Adding an internal JSON view to SlackEventWrapper to avoid serializing tokens in logs and other places we don't mean to