### PR TITLE
Allowing custom rate limiters on the slack client

### DIFF
--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClientRuntimeConfigIF.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClientRuntimeConfigIF.java
@@ -11,6 +11,8 @@ import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.interceptors.calls.SlackMethodAcceptor;
 import com.hubspot.slack.client.interceptors.http.RequestDebugger;
 import com.hubspot.slack.client.interceptors.http.ResponseDebugger;
+import com.hubspot.slack.client.ratelimiting.ByMethodRateLimiter;
+import com.hubspot.slack.client.ratelimiting.SlackRateLimiter;
 
 @Immutable
 @HubSpotStyle
@@ -41,6 +43,8 @@ public interface SlackClientRuntimeConfigIF {
   default Supplier<Integer> getConversationsHistoryMessageBatchSize() {
     return () -> 1000;
   }
+
+  Optional<SlackRateLimiter> getSlackRateLimiter();
 
   Optional<HttpConfig> getHttpConfig();
 

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/ratelimiting/ByMethodRateLimiter.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/ratelimiting/ByMethodRateLimiter.java
@@ -12,7 +12,7 @@ public class ByMethodRateLimiter implements SlackRateLimiter {
   @Override
   public double acquire(String slackToken, SlackMethod slackMethod) {
     double permissibleQueriesPerSecond = slackMethod.getRateLimitingTier().getMinutelyAllowance() / 60.0;
-    return RATE_LIMITERS.computeIfAbsent( //TODO bwehner this is where we'd call the interface
+    return RATE_LIMITERS.computeIfAbsent(
         slackMethod,
         ignored -> RateLimiter.create(permissibleQueriesPerSecond)
     ).acquire();

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/ratelimiting/ByMethodRateLimiter.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/ratelimiting/ByMethodRateLimiter.java
@@ -1,0 +1,20 @@
+package com.hubspot.slack.client.ratelimiting;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import com.google.common.util.concurrent.RateLimiter;
+import com.hubspot.slack.client.methods.SlackMethod;
+
+public class ByMethodRateLimiter implements SlackRateLimiter {
+  private static final ConcurrentMap<SlackMethod, RateLimiter> RATE_LIMITERS = new ConcurrentHashMap<>();
+
+  @Override
+  public double acquire(String slackToken, SlackMethod slackMethod) {
+    double permissibleQueriesPerSecond = slackMethod.getRateLimitingTier().getMinutelyAllowance() / 60.0;
+    return RATE_LIMITERS.computeIfAbsent( //TODO bwehner this is where we'd call the interface
+        slackMethod,
+        ignored -> RateLimiter.create(permissibleQueriesPerSecond)
+    ).acquire();
+  }
+}

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/ratelimiting/SlackRateLimiter.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/ratelimiting/SlackRateLimiter.java
@@ -1,0 +1,13 @@
+package com.hubspot.slack.client.ratelimiting;
+
+import com.hubspot.slack.client.methods.SlackMethod;
+
+public interface SlackRateLimiter {
+  /**
+   * Acquires a permit, blocking if one cannot be acquired immediately
+   * @param slackToken
+   * @param slackMethod
+   * @return The amount of time spent waiting in seconds
+   */
+  double acquire(String slackToken, SlackMethod slackMethod);
+}


### PR DESCRIPTION
1. Defined a new SlackRateLimiter interface with one method, acquire(String slackToken, SlackMethod slackMethod) which acquires a permit for the given token method combination
2. Defined an implementation ByMethod, which encapsulates the current rate limiting implementation in SlackClient (i.e. the static map of RATE_LIMITERS from method to guave RateLimiter)
3. Adds an option on SlackRuntimeConfig to specify a rate limiter
4. Inject the new ByMethodRateLimiter in SlackWebClient, use it if slackRuntimeConfig.getSlackRateLimiter() is empty

**Testing**
Tested locally by building off branch in slack-integration and running the updateSlackChannels job, which uses Slack Client. Job operated as expected