### PR TITLE
Made SlackMemberJoinedChannelEvent deserialize ChannelType to an enum value directly

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/ChannelType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/ChannelType.java
@@ -1,6 +1,30 @@
 package com.hubspot.slack.client.models;
 
+import java.util.Arrays;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum ChannelType {
-  GROUP,
-  CHANNEL
+  GROUP("G"),
+  CHANNEL("C");
+
+  private final String slackName;
+
+  ChannelType(String slackName) {
+    this.slackName = slackName;
+  }
+
+  @JsonCreator
+  public static ChannelType fromSlackName(String slackName) {
+    return Arrays.stream(ChannelType.values())
+        .filter(enumVal -> enumVal.slackName.toLowerCase().equals(slackName.toLowerCase()))
+        .findFirst()
+        .orElse(CHANNEL);
+  }
+
+  @JsonValue
+  public String toSlackName() {
+    return slackName;
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/SlackChannelIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/SlackChannelIF.java
@@ -22,10 +22,6 @@ public interface SlackChannelIF {
   @Derived
   @JsonIgnore
   default ChannelType getChannelType() {
-    if (getId().toLowerCase().startsWith("g")) {
-      return ChannelType.GROUP;
-    }
-
-    return ChannelType.CHANNEL;
+    return ChannelType.fromSlackName(String.valueOf(getId().charAt(0)));
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/user/SlackMemberJoinedChannelEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/user/SlackMemberJoinedChannelEventIF.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.ChannelType;
 import com.hubspot.slack.client.models.events.SlackEvent;
 
 @Immutable
@@ -23,7 +24,7 @@ public interface SlackMemberJoinedChannelEventIF extends SlackEvent {
   @JsonProperty("channel")
   String getChannelId();
 
-  String getChannelType();
+  ChannelType getChannelType();
 
   String getTeam();
 

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/events/json/EventDeserializerTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/events/json/EventDeserializerTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.hubspot.slack.client.jackson.ObjectMapperUtils;
+import com.hubspot.slack.client.models.ChannelType;
 import com.hubspot.slack.client.models.JsonLoader;
 import com.hubspot.slack.client.models.events.SlackEvent;
 import com.hubspot.slack.client.models.events.SlackEventType;
@@ -95,6 +96,14 @@ public class EventDeserializerTest {
     SlackMemberJoinedChannelEvent event = fetchAndDeserializeSlackEvent("member_joined_channel_with_inviter.json").toDetailedEvent();
     assertThat(event.getType()).isEqualTo(SlackEventType.MEMBER_JOINED_CHANNEL);
     assertTrue(event.getInviterId().isPresent());
+    assertThat(ObjectMapperUtils.mapper().readValue(ObjectMapperUtils.mapper().writeValueAsString(event), SlackMemberJoinedChannelEvent.class)).isEqualTo(event);
+  }
+
+  @Test
+  public void itCanDeserMemberJoinedPrivateChannels() throws IOException {
+    SlackMemberJoinedChannelEvent event = fetchAndDeserializeSlackEvent("member_joined_private_channel.json").toDetailedEvent();
+    assertThat(event.getType()).isEqualTo(SlackEventType.MEMBER_JOINED_CHANNEL);
+    assertThat(event.getChannelType()).isEqualTo(ChannelType.GROUP);
     assertThat(ObjectMapperUtils.mapper().readValue(ObjectMapperUtils.mapper().writeValueAsString(event), SlackMemberJoinedChannelEvent.class)).isEqualTo(event);
   }
 

--- a/slack-base/src/test/resources/member_joined_private_channel.json
+++ b/slack-base/src/test/resources/member_joined_private_channel.json
@@ -1,0 +1,19 @@
+{
+  "token": "redacted",
+  "team_id": "redacted",
+  "api_app_id": "redacted",
+  "event": {
+    "type": "member_joined_channel",
+    "user": "redacted",
+    "channel": "redacted",
+    "channel_type": "G",
+    "team": "redacted",
+    "event_ts": "1540822163.000100"
+  },
+  "type": "event_callback",
+  "event_id": "EvDQSNTKPX",
+  "event_time": 1540822163,
+  "authed_users": [
+    "redacted"
+  ]
+}


### PR DESCRIPTION
Also updated SlackChannel to use the new slack channel type name -> ChannelType mapping

**Testing**
Added unit test for deserializing private channel