### PR TITLE
seconds not milliseconds

### DIFF
--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
@@ -962,8 +962,8 @@ public class SlackWebClient implements SlackClient {
         method,
         ignored -> RateLimiter.create(permissibleQps)
     ).acquire();
-    if (acquireTime > 10.0) {
-      LOG.warn("Throttling {}, waited {}ms to acquire permit to run", method, acquireTime);
+    if (acquireTime > 5.0) {
+      LOG.warn("Throttling {}, waited {} seconds to acquire permit to run", method, acquireTime);
     }
   }
 


### PR DESCRIPTION
The default rate limiter throttles in _seconds_ not milliseconds. Very important to log this right. 

I've also dropped log warning time to 5 seconds since 5 seconds is a long API call. Worthwhile to know if it's waiting that long