### PR TITLE
add user_not_found to error type list

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorType.java
@@ -67,7 +67,8 @@ public enum SlackErrorType {
 
   TOKEN_REVOKED("token_revoked"),
 
-  USERS_NOT_FOUND("users_not_found"),
+  USER_NOT_FOUND("user_not_found"), // all APIs except users.lookupByEmail
+  USERS_NOT_FOUND("users_not_found"), // users.lookupByEmail
   USERS_NOT_VISIBLE("user_not_visible"),
   USER_NOT_IN_CHANNEL("user_not_in_channel"),
   USER_IS_BOT("user_is_bot"),

--- a/slack-java-client-examples/pom.xml
+++ b/slack-java-client-examples/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>slack-client</artifactId>
     <groupId>com.hubspot.slack</groupId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>slack-java-client-examples</artifactId>


### PR DESCRIPTION
### [users.lookupByEmail](https://api.slack.com/methods/users.lookupByEmail)

![users_not_found error](https://user-images.githubusercontent.com/5615725/50609994-62b30880-0e9f-11e9-9f6d-de76e4774876.png)

### [users.info](https://api.slack.com/methods/users.info) (and all the other ones I found)
![user_not_found error](https://user-images.githubusercontent.com/5615725/50610036-85ddb800-0e9f-11e9-9316-26790d19963e.png)

cc @szabowexler 

