### PR TITLE
Update DialogSubmission body

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/DialogSubmissionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/DialogSubmissionIF.java
@@ -19,4 +19,9 @@ public interface DialogSubmissionIF extends SlackInteractiveCallback {
    * where the keys are the field names used when creating the dialog.
    */
   Map<String, Optional<String>> getSubmission();
+  
+  /**
+   * The state that was passed to the dialog when it was opened.
+   */
+  String getState();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/DialogSubmissionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/DialogSubmissionIF.java
@@ -19,7 +19,7 @@ public interface DialogSubmissionIF extends SlackInteractiveCallback {
    * where the keys are the field names used when creating the dialog.
    */
   Map<String, Optional<String>> getSubmission();
-  
+
   /**
    * The state that was passed to the dialog when it was opened.
    */


### PR DESCRIPTION
Related to [this recent PR](https://github.com/HubSpot/slack-client/pull/79), which added `state` to the body of the dialog-open request. This PR seeks to add `state` to the body of the dialog submission request, making the change full-circle.