### PR TITLE
Adding JPG file type

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/SlackDialogIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/SlackDialogIF.java
@@ -54,7 +54,7 @@ public interface SlackDialogIF {
 
     getState().ifPresent(state -> {
       if (state.length() > 3000) {
-        throw new IllegalStateException("State cannot exist 3000 chars, got " + state.length());
+        throw new IllegalStateException("State cannot exceed 3000 chars, got " + state.length());
       }
     });
 

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
@@ -16,7 +16,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 @JsonSubTypes({
     @JsonSubTypes.Type(value = SlackTextFile.class, name = "text"),
     @JsonSubTypes.Type(value = SlackCsvFile.class, name = "csv"),
-    @JsonSubTypes.Type(value = SlackGifFile.class, name = "gif")
+    @JsonSubTypes.Type(value = SlackGifFile.class, name = "gif"),
+    @JsonSubTypes.Type(value = SlackJpgFile.class, name = "jpg")
 })
 public interface SlackFile {
   String getId();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileType.java
@@ -9,6 +9,7 @@ public enum SlackFileType {
   TEXT("text"),
   GIF("gif"),
   CSV("csv"),
+  JPG("jpg")
   ;
 
   final String type;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileType.java
@@ -9,7 +9,7 @@ public enum SlackFileType {
   TEXT("text"),
   GIF("gif"),
   CSV("csv"),
-  JPG("jpg")
+  JPG("jpg"),
   ;
 
   final String type;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackJpgFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackJpgFileIF.java
@@ -8,7 +8,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @HubSpotStyle
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-public interface SlackJpgFileIF extends SlackTextFileCore {
+public interface SlackJpgFileIF extends SlackImageFile {
     @Value.Default
     @Override
     default SlackFileType getFiletype() {

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackJpgFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackJpgFileIF.java
@@ -1,0 +1,17 @@
+package com.hubspot.slack.client.models.files;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public interface SlackJpgFileIF extends SlackTextFileCore {
+    @Value.Default
+    @Override
+    default SlackFileType getFiletype() {
+        return SlackFileType.JPG;
+    }
+}


### PR DESCRIPTION
\closes https://github.com/HubSpot/slack-client/issues/76

However, we would want to maybe consider a different implementation in order to add all the file types here https://api.slack.com/types/file ?