### PR TITLE
Adding state to dialog submission

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/DialogSubmissionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/DialogSubmissionIF.java
@@ -19,4 +19,9 @@ public interface DialogSubmissionIF extends SlackInteractiveCallback {
    * where the keys are the field names used when creating the dialog.
    */
   Map<String, Optional<String>> getSubmission();
+
+  /**
+   * This state is passed from the dialog creation and is echoed back from the user submission.
+   */
+  Optional<String> getState();
 }


### PR DESCRIPTION
Implementing changes from https://github.com/HubSpot/slack-client/pull/80

The dialog submission also contains the state that was passed through when it was created.