### PR TITLE
The bot_id is sometimes included in a message that doesn't have the BOT_MESSAGE subtype

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/AbstractSlackEventMessage.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/AbstractSlackEventMessage.java
@@ -21,6 +21,8 @@ public abstract class AbstractSlackEventMessage extends SlackEventMessageBase im
 
   public abstract Optional<String> getThreadTs();
 
+  public abstract Optional<String> getBotId();
+
   @Override
   @JsonProperty("user")
   public abstract String getUserId();


### PR DESCRIPTION
If a bot posts in a DM, the slack event message that gets posted does not have the BOT_MESSAGE subtype, but instead includes the bot_id. 

E.g. of a _raw_ event - this was sent by a bot in a DM to a (non-bot) user:
```
2019-03-11 15:01:23.934 [dw-122 - POST /wall-e/events] INFO  c.h.p.resources.SlackEventResource - 
Received event {
"token":"[...]",
"team_id":"TEAM123",
"api_app_id":"APP123",

"event":
    {"bot_id":"BOT123",
     "type":"message",
     "text":":wave: Please post links to relevant logs. An engineer will respond soon.",
     "user":"USER123",
     "ts":"1552330883.013000",
     "attachments":[...],
     "thread_ts":"1552330877.012800",
     "parent_user_id":"USER234",
     "channel":"CHAN123",
     "event_ts":"1552330883.013000",
     "channel_type":"channel"},

"type":"event_callback",
"event_id":"Event123",
"event_time":1552330883,
"authed_users":["USER123"]}
```