### PR TITLE
handle "errors" instead of "error" in response

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorResponseIF.java
@@ -1,5 +1,8 @@
 package com.hubspot.slack.client.models.response;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.immutables.value.Value.Immutable;
 
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -7,5 +10,6 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @Immutable
 @HubSpotStyle
 public interface SlackErrorResponseIF extends SlackResponse {
-  SlackError getError();
+  Optional<SlackError> getError();
+  Optional<List<SlackError>> getErrors();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorResponseIF.java
@@ -11,5 +11,5 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @HubSpotStyle
 public interface SlackErrorResponseIF extends SlackResponse {
   Optional<SlackError> getError();
-  Optional<List<SlackError>> getErrors();
+  List<SlackError> getErrors();
 }

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/response/SlackResponseTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/response/SlackResponseTest.java
@@ -9,10 +9,12 @@ import com.hubspot.slack.client.models.response.users.UsersInfoResponse;
 
 public class SlackResponseTest {
 
-  private static final String ERROR_RESPONSE = "{\n" +
+  private static final String ERROR_RESPONSE_SINGLE_ERROR = "{\n" +
       "    \"ok\": false,\n" +
       "    \"error\": \"something_bad\"\n" +
       "}";
+
+  private static final String ERROR_RESPONSE_MULTIPLE_ERRORS = "{\"ok\":false, \"errors\":[{\"ok\":false, \"error\":\"cant_invite_self\"}]}";
 
   private static final String USER_RESPONSE = "{\n" +
       "    \"ok\": true,\n" +
@@ -42,11 +44,18 @@ public class SlackResponseTest {
 
   @Test
   public void itDoesDeserializeErrorResponse() throws Exception {
-    SlackErrorResponse errorResponse = TestMappers.OBJECT_MAPPER.readValue(ERROR_RESPONSE, SlackErrorResponse.class);
+    SlackErrorResponse errorResponse = TestMappers.OBJECT_MAPPER.readValue(ERROR_RESPONSE_SINGLE_ERROR, SlackErrorResponse.class);
 
     assertThat(errorResponse.isOk()).isFalse();
-    assertThat(errorResponse.getError().getError()).isNotEmpty();
-    assertThat(errorResponse.getError().getType()).isEqualTo(SlackErrorType.UNKNOWN);
+    assertThat(errorResponse.getError()).isPresent();
+    assertThat(errorResponse.getError().get().getType()).isEqualTo(SlackErrorType.UNKNOWN);
+
+    SlackErrorResponse errorMultipleResponse = TestMappers.OBJECT_MAPPER.readValue(ERROR_RESPONSE_MULTIPLE_ERRORS, SlackErrorResponse.class);
+
+    assertThat(errorMultipleResponse.isOk()).isFalse();
+    assertThat(errorMultipleResponse.getError()).isNotPresent();
+    assertThat(errorMultipleResponse.getErrors()).isPresent();
+    assertThat(errorMultipleResponse.getErrors().get().get(0).getError()).isEqualTo("cant_invite_self");
   }
 
   @Test

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/response/SlackResponseTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/response/SlackResponseTest.java
@@ -54,8 +54,8 @@ public class SlackResponseTest {
 
     assertThat(errorMultipleResponse.isOk()).isFalse();
     assertThat(errorMultipleResponse.getError()).isNotPresent();
-    assertThat(errorMultipleResponse.getErrors()).isPresent();
-    assertThat(errorMultipleResponse.getErrors().get().get(0).getError()).isEqualTo("cant_invite_self");
+    assertThat(errorMultipleResponse.getErrors()).isNotEmpty();
+    assertThat(errorMultipleResponse.getErrors().get(0).getError()).isEqualTo("cant_invite_self");
   }
 
   @Test

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
@@ -922,7 +922,7 @@ public class SlackWebClient implements SlackClient {
 
             SlackErrorResponse errorResponse = ObjectMapperUtils.mapper().treeToValue(response.getAsJsonNode(), SlackErrorResponse.class);
             responseDebugger.debugSlackApiError(requestId, method, request, response);
-            return Result.err(errorResponse.getError().orElseGet(() -> errorResponse.getErrors().get().get(0)));
+            return Result.err(errorResponse.getError().orElseGet(() -> errorResponse.getErrors().get(0)));
           } catch (JsonProcessingException e) {
             responseDebugger.debugProcessingFailure(requestId, method, request, response, e);
             return Result.err(SlackError.builder()

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
@@ -89,6 +89,7 @@ import com.hubspot.slack.client.models.group.SlackGroup;
 import com.hubspot.slack.client.models.response.FindRepliesResponse;
 import com.hubspot.slack.client.models.response.ResponseMetadata;
 import com.hubspot.slack.client.models.response.SlackError;
+import com.hubspot.slack.client.models.response.SlackErrorResponse;
 import com.hubspot.slack.client.models.response.SlackErrorType;
 import com.hubspot.slack.client.models.response.SlackResponse;
 import com.hubspot.slack.client.models.response.auth.AuthRevokeResponse;
@@ -858,6 +859,7 @@ public class SlackWebClient implements SlackClient {
     return postSlackCommand(SlackMethods.team_info, new Object(), TeamInfoResponse.class);
   }
 
+  @Override
   public <T extends SlackResponse> CompletableFuture<Result<T, SlackError>> postSlackCommand(
       SlackMethod method,
       Object params,
@@ -918,9 +920,9 @@ public class SlackWebClient implements SlackClient {
               return Result.ok(ObjectMapperUtils.mapper().treeToValue(responseJson, responseType));
             }
 
-            SlackError error = ObjectMapperUtils.mapper().treeToValue(response.getAsJsonNode(), SlackError.class);
+            SlackErrorResponse errorResponse = ObjectMapperUtils.mapper().treeToValue(response.getAsJsonNode(), SlackErrorResponse.class);
             responseDebugger.debugSlackApiError(requestId, method, request, response);
-            return Result.err(error);
+            return Result.err(errorResponse.getError().orElseGet(() -> errorResponse.getErrors().get().get(0)));
           } catch (JsonProcessingException e) {
             responseDebugger.debugProcessingFailure(requestId, method, request, response, e);
             return Result.err(SlackError.builder()


### PR DESCRIPTION
Sometimes the slack API is returning a list of `errors` instead of `error`. While not perfect, this causes the client to not break on that response.