### PR TITLE
Updating README to reference 'breaking changes' guidelines.

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -19,8 +19,8 @@ The main reason for this process is to be proactive and prevent possible future 
 
 There are 2 changelogs: current and future.
 
-[Current](https://api.slack.com/changelog)
-[Future](https://api.slack.com/changelog/future)
+* [Current](https://api.slack.com/changelog)
+* [Future](https://api.slack.com/changelog/future)
 
 The former contains recent changes and dates on when an endpoint will be changed in a possible breaking way.
 The latter shows proposed future changes.

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -7,6 +7,7 @@
 * [Overview](#overview)
 * [Changelogs](#changelogs)
 * [Audit](#audit)
+* [History](#history)
 
 ## Overview
 
@@ -31,10 +32,17 @@ Both should be read through when determining if the changes affect us.
 
 The following is a list of proposed steps to take in order to make sure that `slack-client` stays stable and on the latest working Slack Web API.
 
-* Read the docs above for possible “breaking changes”. It's generally a good idea to go back a few months and see if anything changed.
+* Read the docs above for possible “breaking changes”. It's generally a good idea to go back a few months and see if anything changed. See `History` and don't revisit the same stuff.
 * Look for red APIs found throughout their docs above. These indicate the change could be breaking.
 * Every month, generate a list of changes to look out for.Make sure that the prior months' lists didn't already include the same breaking change. We don’t want to verify the same change twice.
 * For each change, we should audit the `slack-client` code and see if it affects us.
 * If we find anything that requires further investigation or actual code changes, an issue should be logged [here](https://github.com/HubSpot/slack-client/issues) with the label `breaking change`.
 * If HubSpot is making the change, it's recommended that an internal ZenHub task is created to track this as well. Reference the github issue above.
 * We should aim to wrap up issues with several weeks to spare. If a deadline for a breaking change is the end of June, we should have something ready in early June if at all possible.
+* We should add a record of this audit to `History` table. Make sure to document where in changelog docs you went to so we can reference next time and not revisit.
+
+## History
+
+| Date | Found Issues | Description |
+| ---- | ------------ | ----------- |
+| | | |

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -1,0 +1,40 @@
+# Slack Web API Breaking Changes
+
+[![license](https://img.shields.io/github/license/HubSpot/slack-client.svg?style=social)](https://github.com/HubSpot/slack-client/blob/master/LICENSE)
+[![GitHub last commit](https://img.shields.io/github/last-commit/HubSpot/slack-client.svg?style=social)](https://github.com/HubSpot/slack-client/commits/master)
+ [![Build Status](https://travis-ci.org/HubSpot/slack-client.svg?branch=master)](https://travis-ci.org/HubSpot/slack-client) [![GitHub release](https://img.shields.io/github/release/HubSpot/slack-client.svg)](https://github.com/HubSpot/slack-client/releases) ![Maven metadata URI](https://img.shields.io/maven-metadata/v/http/central.maven.org/maven2/com/hubspot/slack/slack-client/maven-metadata.xml.svg)
+
+* [Overview](#overview)
+* [Changelogs](#changelogs)
+* [Audit](#audit)
+
+## Overview
+
+Every so often, companies will issue “breaking changes” whether they’re officially calling them that or not.
+You can think of a breaking change as any modification or deletion of an api endpoint that would adversely affect the `slack-client`.
+
+The main reason for this process is to be proactive and prevent possible future bugs in the `slack-client`.
+
+## Changelogs
+
+There are 2 changelogs: current and future.
+
+[Current](https://api.slack.com/changelog)
+[Future](https://api.slack.com/changelog/future)
+
+The former contains recent changes and dates on when an endpoint will be changed in a possible breaking way.
+The latter shows proposed future changes.
+
+Both should be read through when determining if the changes affect us.
+
+## Audit
+
+The following is a list of proposed steps to take in order to make sure that `slack-client` stays stable and on the latest working Slack Web API.
+
+* Read the docs above for possible “breaking changes”. It's generally a good idea to go back a few months and see if anything changed.
+* Look for red APIs found throughout their docs above. These indicate the change could be breaking.
+* Every month, generate a list of changes to look out for.Make sure that the prior months' lists didn't already include the same breaking change. We don’t want to verify the same change twice.
+* For each change, we should audit the `slack-client` code and see if it affects us.
+* If we find anything that requires further investigation or actual code changes, an issue should be logged [here](https://github.com/HubSpot/slack-client/issues) with the label `breaking change`.
+* If HubSpot is making the change, it's recommended that an internal ZenHub task is created to track this as well. Reference the github issue above.
+* We should aim to wrap up issues with several weeks to spare. If a deadline for a breaking change is the end of June, we should have something ready in early June if at all possible.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
  [![Build Status](https://travis-ci.org/HubSpot/slack-client.svg?branch=master)](https://travis-ci.org/HubSpot/slack-client) [![GitHub release](https://img.shields.io/github/release/HubSpot/slack-client.svg)](https://github.com/HubSpot/slack-client/releases) ![Maven metadata URI](https://img.shields.io/maven-metadata/v/http/central.maven.org/maven2/com/hubspot/slack/slack-client/maven-metadata.xml.svg) 
  
 * [Overview](#overview)
+* [Maintenance](#maintenance)
 * [Features](#features)
 * [Usage](#usage)
 * [Setting up Guice](#setting-up-guice)
@@ -20,6 +21,11 @@ An asychronous HTTP client wrapping Slack's [RPC-style web api](https://api.slac
 * Actively maintain this project
 * Provide per-method in-memory rate limiting so you don't have to worry about overwhelming slack from a single process
 * Expose highly configurable hooks to allow custom rate limiting, method filtering, and debugging in an extensible way
+
+## Maintenance
+
+Like most APIs, deprecations and modifications that we'll call "breaking changes" will occur on Slack's web API.
+General guidelines on detecting and handling "breaking changes" can be found [here](https://github.com/HubSpot/slack-client/blob/master/DEV_README.md)
 
 ## Features
 


### PR DESCRIPTION
The following is a **proposed** plan on how to find and handle "breaking changes".

I'm happy to make any changes to the frequency or process when we find a possible issue. The main thing I wanted to provide was a way for us to be proactive and prevent our slack client from breaking in the future due to a foreseeable change.