### PR TITLE
add cannot_dm_bot error

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorType.java
@@ -17,6 +17,7 @@ public enum SlackErrorType {
   CANT_DELETE_MESSAGE("cant_delete_message"),
   CANT_UPDATE_MESSAGE("cant_update_message"),
   CANNOT_CREATE_DIALOG("cannot_create_dialog"),
+  CANNOT_DM_BOT("cannot_dm_bot"),
   CHANNEL_NOT_FOUND("channel_not_found"),
   COMPLIANCE_EXPORTS_PREVENT_DELETION("compliance_exports_prevent_deletion"),
 


### PR DESCRIPTION
We've seen the error `cannot_dm_bot` come through when trying to DM a bot. This error is undocumented so we reached out to Slack to understand the issue. They said

> It would appear that the error cannot_dm_bot is thrown because a dm between two bots can not exisit. If the im.open method is being called with a bot token xoxb then this is likely the reason.

I tested this and was able to reproduce this by utilizing an authorized bot token (xoxb-*) and hitting `im.open` for a bot user ID. Note: this only appears if using a bot token provided during the install authorization. It cannot be the bot token listed in the app's "OAuth & Permissions" page. If the app's "OAuth & Permissions" bot token is used, we see "user_not_found."
