### PR TITLE
Expose file

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/LiteMessageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/LiteMessageIF.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.files.SlackFile;
 
 @Immutable
 @HubSpotStyle
@@ -23,6 +24,7 @@ public interface LiteMessageIF {
   String getText();
 
   List<Attachment> getAttachments();
+  Optional<SlackFile> getFile();
 
   @JsonProperty("ts")
   String getTimestamp();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/LiteMessageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/LiteMessageIF.java
@@ -24,7 +24,7 @@ public interface LiteMessageIF {
   String getText();
 
   List<Attachment> getAttachments();
-  Optional<SlackFile> getFile();
+  List<SlackFile> getFiles();
 
   @JsonProperty("ts")
   String getTimestamp();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
@@ -2,6 +2,8 @@ package com.hubspot.slack.client.models.files;
 
 import java.util.List;
 
+import org.immutables.value.Value.Default;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -52,7 +54,11 @@ public interface SlackFile {
   String getPermalink();
   String getPermalinkPublic();
 
-  int getCommentsCount();
+  @Default
+  default int getCommentsCount() {
+    return 0;
+  }
+
   @JsonProperty("is_starred")
   boolean isStarred();
 

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
@@ -17,7 +17,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
     @JsonSubTypes.Type(value = SlackTextFile.class, name = "text"),
     @JsonSubTypes.Type(value = SlackCsvFile.class, name = "csv"),
     @JsonSubTypes.Type(value = SlackGifFile.class, name = "gif"),
-    @JsonSubTypes.Type(value = SlackJpgFile.class, name = "jpg")
+    @JsonSubTypes.Type(value = SlackJpgFile.class, name = "jpg"),
+    @JsonSubTypes.Type(value = SlackPngFile.class, name = "png")
 })
 public interface SlackFile {
   String getId();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileType.java
@@ -10,6 +10,7 @@ public enum SlackFileType {
   GIF("gif"),
   CSV("csv"),
   JPG("jpg"),
+  PNG("png"),
   ;
 
   final String type;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackPngFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackPngFileIF.java
@@ -1,0 +1,18 @@
+package com.hubspot.slack.client.models.files;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Value.Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public interface SlackPngFileIF extends SlackImageFile {
+    @Value.Default
+    @Override
+    default SlackFileType getFiletype() {
+        return SlackFileType.PNG;
+    }
+}


### PR DESCRIPTION
When issues a find replies request, files come back. This exposes them, and adds PNG support.