### PR TITLE
Add a default parser to handle unknown/unsupported filetypes without breaking

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
@@ -13,7 +13,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 @JsonTypeInfo(
     use = Id.NAME,
     include = As.EXISTING_PROPERTY,
-    property = "filetype"
+    property = "filetype",
+    defaultImpl = SlackUnknownFiletype.class
 )
 @JsonSubTypes({
     @JsonSubTypes.Type(value = SlackTextFile.class, name = "text"),

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileType.java
@@ -11,6 +11,7 @@ public enum SlackFileType {
   CSV("csv"),
   JPG("jpg"),
   PNG("png"),
+  UNKNOWN("unknown"),
   ;
 
   final String type;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackUnknownFiletypeIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackUnknownFiletypeIF.java
@@ -1,0 +1,17 @@
+package com.hubspot.slack.client.models.files;
+
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface SlackUnknownFiletypeIF extends SlackFile {
+  @Override
+  default SlackFileType getFiletype() {
+    return SlackFileType.UNKNOWN;
+  }
+}


### PR DESCRIPTION
This is a followup to #93. That PR inadvertently broke users, because we don't have complete support for the [full list of Slack filetypes](https://api.slack.com/types/file). In this PR, we add a default deserializer that exposes the core set of attributes we know every file will have. This can be expanded in the future by adding explicit support for desired files for deserialization, but this here will ensure there are no runtime exceptions on new files.