### PR TITLE
Make default have sentinel values for EVERYTHING

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
@@ -22,7 +22,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
     @JsonSubTypes.Type(value = SlackCsvFile.class, name = "csv"),
     @JsonSubTypes.Type(value = SlackGifFile.class, name = "gif"),
     @JsonSubTypes.Type(value = SlackJpgFile.class, name = "jpg"),
-    @JsonSubTypes.Type(value = SlackPngFile.class, name = "png")
+    @JsonSubTypes.Type(value = SlackPngFile.class, name = "png"),
+    @JsonSubTypes.Type(value = SlackUnknownFiletype.class, name = "unknown")
 })
 public interface SlackFile {
   String getId();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
@@ -22,8 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
     @JsonSubTypes.Type(value = SlackCsvFile.class, name = "csv"),
     @JsonSubTypes.Type(value = SlackGifFile.class, name = "gif"),
     @JsonSubTypes.Type(value = SlackJpgFile.class, name = "jpg"),
-    @JsonSubTypes.Type(value = SlackPngFile.class, name = "png"),
-    @JsonSubTypes.Type(value = SlackUnknownFiletype.class, name = "unknown")
+    @JsonSubTypes.Type(value = SlackPngFile.class, name = "png")
 })
 public interface SlackFile {
   String getId();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackUnknownFiletypeIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackUnknownFiletypeIF.java
@@ -6,10 +6,13 @@ import java.util.Optional;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 
 @Immutable
 @HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
 public interface SlackUnknownFiletypeIF extends SlackFile {
   @Override
   @Default

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackUnknownFiletypeIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackUnknownFiletypeIF.java
@@ -1,17 +1,148 @@
 package com.hubspot.slack.client.models.files;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 
 @Immutable
 @HubSpotStyle
-@JsonNaming(SnakeCaseStrategy.class)
 public interface SlackUnknownFiletypeIF extends SlackFile {
   @Override
+  @Default
+  default String getId() {
+    return "unknown";
+  }
+
+  @Override
+  @Default
+  default long getCreatedEpochSeconds() {
+    return -1;
+  }
+
+  @Override
+  @Default
+  default long getTimestampEpochSeconds() {
+    return -1;
+  }
+
+  @Override
+  @Default
+  default String getName() {
+    return "unknown";
+  }
+
+  @Override
+  @Default
+  default String getTitle() {
+    return "unknown";
+  }
+
+  @Override
+  @Default
+  default String getMimetype() {
+    return "unknown";
+  }
+
+  @Override
+  @Default
   default SlackFileType getFiletype() {
     return SlackFileType.UNKNOWN;
   }
+
+  @Override
+  @Default
+  default String getPrettyType() {
+    return "unknown";
+  }
+
+  @Override
+  @Default
+  default String getUserId() {
+    return "unknown";
+  }
+
+  @Override
+  @Default
+  default boolean isEditable() {
+    return false;
+  }
+
+  @Override
+  @Default
+  default long getSize() {
+    return -1;
+  }
+
+  @Override
+  @Default
+  default String getMode() {
+    return "unknown";
+  }
+
+  @Override
+  @Default
+  default boolean isExternal() {
+    return false;
+  }
+
+  @Override
+  @Default
+  default boolean isPublic() {
+    return false;
+  }
+
+  @Override
+  @Default
+  default boolean isPublicUrlShared() {
+    return false;
+  }
+
+  @Override
+  @Default
+  default boolean getDisplayAsBot() {
+    return false;
+  }
+
+  @Override
+  @Default
+  default String getUsername() {
+    return "unknown";
+  }
+
+  @Override
+  @Default
+  default String getUrlPrivate() {
+    return "unknown";
+  }
+
+  @Override
+  Optional<String> getUrlPrivateDownload();
+
+  @Override
+  @Default
+  default String getPermalink() {
+    return "unknown";
+  }
+
+  @Override
+  Optional<String> getPermalinkPublic();
+
+  @Override
+  @Default
+  default int getCommentsCount() {
+    return 0;
+  }
+
+  @Override
+  Optional<Boolean> isStarred();
+  @Override
+  List<String> getChannelIds();
+  @Override
+  List<String> getGroupIds();
+  @Override
+  List<String> getImIds();
 }


### PR DESCRIPTION
Follow up to #95 and #94. Basically there's huge variance in what fields are actually present, which can lead to strange runtime exceptions when you hit new file types. 

This PR adds default values for basically everything, which should mean that the unknown file type effectively can't fail to parse.