### PR TITLE
allow proactive rate limiting

### DIFF
--- a/slack-java-client-examples/src/main/java/com/hubspot/slack/client/examples/CustomDebugConfig.java
+++ b/slack-java-client-examples/src/main/java/com/hubspot/slack/client/examples/CustomDebugConfig.java
@@ -43,6 +43,11 @@ public class CustomDebugConfig {
           public void debugProcessingFailure(long requestId, SlackMethod method, HttpRequest request, HttpResponse response, Throwable ex) {
             // problem in the client code itself resulted in failure
           }
+
+          @Override
+          public void debugProactiveRateLimit(long requestId, SlackMethod method, HttpRequest request) {
+            // configured rate limiter prevented request
+          }
         })
         .build();
   }

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
@@ -142,6 +142,7 @@ import com.hubspot.slack.client.ratelimiting.SlackRateLimiter;
 
 public class SlackWebClient implements SlackClient {
   public static final int RATE_LIMIT_SENTINEL_VALUE = -1;
+  public static final int RATE_LIMIT_LOG_WARNING_THRESHOLD_SECONDS = 5;
 
   private static final Logger LOG = LoggerFactory.getLogger(SlackWebClient.class);
   private static final HttpConfig DEFAULT_CONFIG = HttpConfig.newBuilder()
@@ -1018,7 +1019,7 @@ public class SlackWebClient implements SlackClient {
 
   private double acquirePermit(SlackMethod method) {
     double acquireSeconds = getSlackRateLimiter().acquire(config.getTokenSupplier().get(), method);
-    if (acquireSeconds > 5.0) {
+    if (acquireSeconds > RATE_LIMIT_LOG_WARNING_THRESHOLD_SECONDS) {
       LOG.warn("Throttling {}, waited {} seconds to acquire permit to run", method, acquireSeconds);
     }
 

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
 import com.google.common.collect.Multimap;
@@ -140,6 +141,8 @@ import com.hubspot.slack.client.ratelimiting.ByMethodRateLimiter;
 import com.hubspot.slack.client.ratelimiting.SlackRateLimiter;
 
 public class SlackWebClient implements SlackClient {
+  public static final int RATE_LIMIT_SENTINEL_VALUE = -1;
+
   private static final Logger LOG = LoggerFactory.getLogger(SlackWebClient.class);
   private static final HttpConfig DEFAULT_CONFIG = HttpConfig.newBuilder()
       .setObjectMapper(ObjectMapperUtils.mapper())
@@ -930,24 +933,27 @@ public class SlackWebClient implements SlackClient {
         .setUrl(config.getSlackApiBasePath().get() + "/" + method.getMethod());
   }
 
-  private <T extends SlackResponse> CompletableFuture<Result<T, SlackError>> executeLoggedAs(
+  @VisibleForTesting
+  <T extends SlackResponse> CompletableFuture<Result<T, SlackError>> executeLoggedAs(
       SlackMethod method,
       HttpRequest request,
       Class<T> responseType
   ) {
     long requestId = REQUEST_COUNTER.getAndIncrement();
-    return executeLogged(requestId, method, request)
+    requestDebugger.debug(requestId, method, request);
+
+    Stopwatch timer = Stopwatch.createStarted();
+    double acquireSeconds = acquirePermit(method);
+
+    if (acquireSeconds == RATE_LIMIT_SENTINEL_VALUE) {
+      responseDebugger.debugProactiveRateLimit(requestId, method, request);
+      return CompletableFuture.completedFuture(Result.err(SlackError.of(SlackErrorType.RATE_LIMITED.key())));
+    }
+
+    return executeLogged(requestId, method, request, timer)
         .thenApply(response -> {
           try {
-            JsonNode responseJson = response.getAsJsonNode();
-            boolean isOk = responseJson.get("ok").asBoolean();
-            if (isOk) {
-              return Result.ok(ObjectMapperUtils.mapper().treeToValue(responseJson, responseType));
-            }
-
-            SlackErrorResponse errorResponse = ObjectMapperUtils.mapper().treeToValue(response.getAsJsonNode(), SlackErrorResponse.class);
-            responseDebugger.debugSlackApiError(requestId, method, request, response);
-            return Result.err(errorResponse.getError().orElseGet(() -> errorResponse.getErrors().get(0)));
+            return parseSlackResponse(response, responseType, requestId, method, request);
           } catch (JsonProcessingException e) {
             responseDebugger.debugProcessingFailure(requestId, method, request, response, e);
             return Result.err(SlackError.builder()
@@ -960,6 +966,23 @@ public class SlackWebClient implements SlackClient {
             throw ex;
           }
         });
+  }
+
+  private <T extends SlackResponse> Result<T, SlackError> parseSlackResponse(HttpResponse response,
+                                                                             Class<T> responseType,
+                                                                             long requestId,
+                                                                             SlackMethod method,
+                                                                             HttpRequest request) throws JsonProcessingException {
+    JsonNode responseJson = response.getAsJsonNode();
+    boolean isOk = responseJson.get("ok").asBoolean();
+    if (isOk) {
+      return Result.ok(ObjectMapperUtils.mapper().treeToValue(responseJson, responseType));
+    }
+
+    SlackErrorResponse errorResponse = ObjectMapperUtils.mapper()
+        .treeToValue(response.getAsJsonNode(), SlackErrorResponse.class);
+    responseDebugger.debugSlackApiError(requestId, method, request, response);
+    return Result.err(errorResponse.getError().orElseGet(() -> errorResponse.getErrors().get(0)));
   }
 
   private <T extends SlackResponse> CompletableFuture<Result<T, SlackError>> postSlackCommandUrlEncoded(
@@ -978,18 +1001,13 @@ public class SlackWebClient implements SlackClient {
   private CompletableFuture<HttpResponse> executeLogged(
       long requestId,
       SlackMethod method,
-      HttpRequest request
-  ) {
-    requestDebugger.debug(requestId, method, request);
-    Stopwatch timer = Stopwatch.createStarted();
-
-    acquirePermit(method);
+      HttpRequest request,
+      Stopwatch timer) {
     CompletableFuture<HttpResponse> responseFuture = nioHttpClient.executeCompletableFuture(request);
 
     responseFuture.whenComplete((httpResponse, throwable) -> {
       if (throwable != null) {
         responseDebugger.debugTransportException(requestId, method, request, throwable);
-
       } else {
         responseDebugger.debug(requestId, method, timer, request, httpResponse);
       }
@@ -998,11 +1016,13 @@ public class SlackWebClient implements SlackClient {
     return responseFuture;
   }
 
-  private void acquirePermit(SlackMethod method) {
-    double acquireTime = getSlackRateLimiter().acquire(config.getTokenSupplier().get(), method);
-    if (acquireTime > 5.0) {
-      LOG.warn("Throttling {}, waited {} seconds to acquire permit to run", method, acquireTime);
+  private double acquirePermit(SlackMethod method) {
+    double acquireSeconds = getSlackRateLimiter().acquire(config.getTokenSupplier().get(), method);
+    if (acquireSeconds > 5.0) {
+      LOG.warn("Throttling {}, waited {} seconds to acquire permit to run", method, acquireSeconds);
     }
+
+    return acquireSeconds;
   }
 
   private SlackRateLimiter getSlackRateLimiter() {

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/interceptors/http/DefaultHttpResponseDebugger.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/interceptors/http/DefaultHttpResponseDebugger.java
@@ -54,4 +54,9 @@ public class DefaultHttpResponseDebugger implements ResponseDebugger {
   ) {
     LOG.error("REQ<{}> [{}]: Failed interaction\n{}\n{}", requestId, method, HttpFormatter.formatRequest(request), HttpFormatter.formatResponse(response), ex);
   }
+
+  @Override
+  public void debugProactiveRateLimit(long requestId, SlackMethod method, HttpRequest request) {
+    LOG.debug("REQ<{}> [{}]: Proactively rate limited request\n{}", requestId, method, HttpFormatter.formatRequest(request));
+  }
 }

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/interceptors/http/ResponseDebugger.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/interceptors/http/ResponseDebugger.java
@@ -37,4 +37,10 @@ public interface ResponseDebugger {
       HttpResponse response,
       Throwable ex
   );
+
+  void debugProactiveRateLimit(
+      long requestId,
+      SlackMethod method,
+      HttpRequest request
+  );
 }

--- a/slack-java-client/src/test/java/com/hubspot/slack/client/SlackWebClientTest.java
+++ b/slack-java-client/src/test/java/com/hubspot/slack/client/SlackWebClientTest.java
@@ -1,0 +1,35 @@
+package com.hubspot.slack.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.hubspot.algebra.Result;
+import com.hubspot.horizon.HttpRequest;
+import com.hubspot.slack.client.methods.SlackMethods;
+import com.hubspot.slack.client.models.response.SlackError;
+import com.hubspot.slack.client.models.response.SlackErrorType;
+import com.hubspot.slack.client.models.response.SlackResponse;
+
+public class SlackWebClientTest {
+
+  @Test
+  public void itProactivelyRateLimits() {
+    SlackWebClient slackClient = (SlackWebClient) SlackClientFactory.defaultFactory().create(SlackClientRuntimeConfig.builder()
+            .setTokenSupplier(() -> "xoxp-test-token")
+            .setRequestDebugger((requestId, method, request) -> {})
+            .setSlackRateLimiter((slackToken, slackMethod) -> SlackWebClient.RATE_LIMIT_SENTINEL_VALUE)
+            .build());
+
+    Result<SlackResponse, SlackError> result = slackClient.executeLoggedAs(SlackMethods.api_test,
+        HttpRequest.newBuilder()
+            .setUrl("api.slack.com/" + SlackMethods.api_test.getMethod())
+            .build(),
+        null)
+        .join();
+
+    assertThat(result.isErr()).isTrue();
+    assertThat(result.unwrapErrOrElseThrow().getType()).isEqualTo(SlackErrorType.RATE_LIMITED);
+    assertThat(result.unwrapErrOrElseThrow().getError()).isEqualTo(SlackErrorType.RATE_LIMITED.key());
+  }
+}


### PR DESCRIPTION
The current rate limiter implementation asks, "when can we send a request" rather than "should we send a request." There's no easy way to proactively stop a request from going out if we know it'll fail. With the current implementation, we must either wait until the request can be sent (bad for high throughput services) or throw an exception (not ideal).

This PR adds support for returning a value to indicate the request was proactively rate limited. Proactively rate limiting means the request won't go out to Slack and the method caller can handle the rate limit just as they would have if Slack had actually rate limited.

@mindspin311 
@igorushakov
cc @szabowexler 