### PR TITLE
Handling removal of the  property on messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ An asychronous HTTP client wrapping Slack's [RPC-style web api](https://api.slac
 * Provide per-method in-memory rate limiting so you don't have to worry about overwhelming slack from a single process
 * Expose highly configurable hooks to allow custom rate limiting, method filtering, and debugging in an extensible way
 
+
+## Breaking Changes
+
+**NOTICE:**
+
+On October 18th 2019, Slack will stop supporting the `replies` thread on a `Message`.
+Due to this, we are deprecating `getReplies()` on [`LiteMessage`](https://github.com/HubSpot/slack-client/blob/master/slack-base/src/main/java/com/hubspot/slack/client/models/LiteMessageIF.java) and [`SlackReplyMessage`](https://github.com/HubSpot/slack-client/blob/master/slack-base/src/main/java/com/hubspot/slack/client/models/events/util/AbstractSlackReplyMessage.java) and it will now just return an empty array as of now.
+More context in the [April 2019 changelog](https://api.slack.com/changelog)
+
+You can continue to use an older version of this client until October 18th, at which time you'll need to upgrade to the latest.
+
+
 ## Maintenance
 
 Like most APIs, deprecations and modifications that we'll call "breaking changes" will occur on Slack's web API.

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/LiteMessageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/LiteMessageIF.java
@@ -1,10 +1,13 @@
 package com.hubspot.slack.client.models;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.immutables.value.Value.Derived;
 import org.immutables.value.Value.Immutable;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -16,21 +19,45 @@ import com.hubspot.slack.client.models.files.SlackFile;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface LiteMessageIF {
   String getType();
+
   Optional<String> getSubtype();
 
   Optional<String> getUser();
+
   Optional<String> getBotId();
+
   Optional<String> getUsername();
+
   String getText();
 
   List<Attachment> getAttachments();
+
   List<SlackFile> getFiles();
 
   @JsonProperty("ts")
   String getTimestamp();
+
   @JsonProperty("thread_ts")
   Optional<String> getThreadTimestamp();
 
   Optional<Integer> getReplyCount();
-  List<ReplySkeleton> getReplies();
+
+  Optional<List<String>> getReplyUsers();
+
+  Optional<Integer> getResplyUsersCount();
+
+  @JsonProperty("latest_reply")
+  Optional<String> getLatestReplyTimestamp();
+
+  /**
+   * @deprecated use {@link #getReplyUsers()} or {@link #getLatestReplyTimestamp()}
+   * These can be used to find the user ids and the last reply timestamp.
+   * Used to return a list of `ReplySkeleton`
+   */
+  @Deprecated
+  @Derived
+  @JsonIgnore
+  default List getReplies() {
+    return Collections.emptyList();
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/ReplySkeletonIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/ReplySkeletonIF.java
@@ -10,6 +10,7 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
+@Deprecated
 public interface ReplySkeletonIF {
   @JsonProperty("user")
   String getUserId();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/util/AbstractSlackReplyMessage.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/util/AbstractSlackReplyMessage.java
@@ -1,10 +1,14 @@
 package com.hubspot.slack.client.models.events.util;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Derived;
 import org.immutables.value.Value.Immutable;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -26,10 +30,27 @@ public abstract class AbstractSlackReplyMessage extends SlackEventMessageBase im
   @JsonProperty("channel")
   public abstract String getChannelId();
 
-  public abstract List<Reply> getReplies();
-
   @Default
   public int getReplyCount() {
     return 0;
+  }
+
+  public abstract Optional<List<String>> getReplyUsers();
+
+  public abstract Optional<Integer> getResplyUsersCount();
+
+  @JsonProperty("latest_reply")
+  public abstract Optional<String> getLatestReplyTimestamp();
+
+  /**
+   * @deprecated use {@link #getReplyUsers()} or {@link #getLatestReplyTimestamp()}
+   * These can be used to find the user ids and the last reply timestamp.
+   * Used to return a list of `ReplySkeleton`
+   */
+  @Deprecated
+  @Derived
+  @JsonIgnore
+  public List getReplies() {
+    return Collections.emptyList();
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/util/ReplyIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/util/ReplyIF.java
@@ -6,6 +6,7 @@ import com.hubspot.immutables.style.HubSpotStyle;
 
 @Immutable
 @HubSpotStyle
+@Deprecated
 public interface ReplyIF {
   String getUser();
   String getTs();


### PR DESCRIPTION
Slack id deprecating `replies` on messages. See [April 2019 changelog](https://api.slack.com/changelog)

I audited our repos that use `slack-client` and didn't see anyone actually call `getReplies()`, so I think that just having it return an empty array is the way to go. The new methods are now included and can be used going forward.