### PR TITLE
#89: Add support for Block Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ If you're not familiar with Java 8's `CompletableFuture` API, know that you can 
 
 
 ## Contributors
+ - [@johnnyleitrim](https://github.com/johnnyleitrim) | [:computer:](https://github.com/HubSpot/slack-client/commits?author=johnnyleitrim)
  - [@szabowexler](https://github.com/szabowexler) | [:computer:](https://github.com/HubSpot/slack-client/commits?author=szabowexler)
  - [@zklapow](https://github.com/zklapow) | [:computer:](https://github.com/HubSpot/slack-client/commits?author=zklapow)
  - [@wsorenson](https://github.com/wsorenson) | [:computer:](https://github.com/HubSpot/slack-client/commits?author=wsorenson)

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/MessageParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/MessageParams.java
@@ -1,7 +1,10 @@
 package com.hubspot.slack.client.methods.params.chat;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
+import org.immutables.value.Value;
 
 import com.hubspot.slack.client.methods.interceptor.HasChannel;
 import com.hubspot.slack.client.models.Attachment;
@@ -12,5 +15,8 @@ public interface MessageParams extends HasChannel {
 
   List<Attachment> getAttachments();
 
-  List<Block> getBlocks();
+  @Value.Default
+  default List<Block> getBlocks() {
+    return Collections.emptyList();
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/MessageParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/MessageParams.java
@@ -5,9 +5,12 @@ import java.util.Optional;
 
 import com.hubspot.slack.client.methods.interceptor.HasChannel;
 import com.hubspot.slack.client.models.Attachment;
+import com.hubspot.slack.client.models.blocks.Block;
 
 public interface MessageParams extends HasChannel {
   Optional<String> getText();
 
   List<Attachment> getAttachments();
+
+  List<Block> getBlocks();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/reactions/ReactionsAddParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/reactions/ReactionsAddParamsIF.java
@@ -17,7 +17,21 @@ public interface ReactionsAddParamsIF {
   String getName();
   Optional<String> getChannel();
   Optional<String> getTimestamp();
+  /**
+   * @deprecated As of 22nd August 2019, Slack has removed support for file comments -
+   * <a href="https://api.slack.com/changelog/2018-05-file-threads-soon-tread#whats_changed">
+   *   file threads are the replacement
+   * </a>
+   */
+  @Deprecated
   Optional<String> getFile();
+  /**
+   * @deprecated As of 22nd August 2019, Slack has removed support for file comments -
+   * <a href="https://api.slack.com/changelog/2018-05-file-threads-soon-tread#whats_changed">
+   *   file threads are the replacement
+   * </a>
+   */
+  @Deprecated
   Optional<String> getFileComment();
 
   @Value.Check

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ActionsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ActionsIF.java
@@ -22,5 +22,6 @@ public interface ActionsIF extends Block {
     return TYPE;
   }
 
+  @Value.Parameter
   List<BlockElement> getElements();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ActionsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ActionsIF.java
@@ -17,7 +17,7 @@ public interface ActionsIF extends Block {
   String TYPE = "actions";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ActionsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ActionsIF.java
@@ -1,0 +1,26 @@
+package com.hubspot.slack.client.models.blocks;
+
+import java.util.List;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.elements.BlockElement;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ActionsIF extends Block {
+  String TYPE = "actions";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  List<BlockElement> getElements();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/Block.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/Block.java
@@ -1,0 +1,23 @@
+package com.hubspot.slack.client.models.blocks;
+
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Actions.class, name = Actions.TYPE),
+    @JsonSubTypes.Type(value = Context.class, name = Context.TYPE),
+    @JsonSubTypes.Type(value = Divider.class, name = Divider.TYPE),
+    @JsonSubTypes.Type(value = File.class, name = File.TYPE),
+    @JsonSubTypes.Type(value = Image.class, name = Image.TYPE),
+    @JsonSubTypes.Type(value = Section.class, name = Section.TYPE),
+})
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public interface Block {
+  String getType();
+
+  Optional<String> getBlockId();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ContextIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ContextIF.java
@@ -19,7 +19,7 @@ public interface ContextIF extends Block {
   String TYPE = "context";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ContextIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ContextIF.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.json.ImageOrTextDeserializer;
+import com.hubspot.slack.client.models.blocks.objects.ImageOrText;
 
 @Immutable
 @HubSpotStyle
@@ -24,5 +25,5 @@ public interface ContextIF extends Block {
   }
 
   @JsonDeserialize(contentUsing = ImageOrTextDeserializer.class)
-  List<Object> getElements();
+  List<ImageOrText> getElements();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ContextIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ContextIF.java
@@ -1,0 +1,26 @@
+package com.hubspot.slack.client.models.blocks;
+
+import java.util.List;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.elements.BlockElement;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ContextIF extends Block {
+  String TYPE = "context";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  List<BlockElement> getElements();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ContextIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ContextIF.java
@@ -25,5 +25,6 @@ public interface ContextIF extends Block {
   }
 
   @JsonDeserialize(contentUsing = ImageBlockOrTextDeserializer.class)
+  @Value.Parameter
   List<ImageBlockOrText> getElements();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ContextIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ContextIF.java
@@ -6,9 +6,10 @@ import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
-import com.hubspot.slack.client.models.blocks.elements.BlockElement;
+import com.hubspot.slack.client.models.blocks.json.ImageOrTextDeserializer;
 
 @Immutable
 @HubSpotStyle
@@ -22,5 +23,6 @@ public interface ContextIF extends Block {
     return TYPE;
   }
 
-  List<BlockElement> getElements();
+  @JsonDeserialize(contentUsing = ImageOrTextDeserializer.class)
+  List<Object> getElements();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ContextIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ContextIF.java
@@ -9,8 +9,8 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
-import com.hubspot.slack.client.models.blocks.json.ImageOrTextDeserializer;
-import com.hubspot.slack.client.models.blocks.objects.ImageOrText;
+import com.hubspot.slack.client.models.blocks.json.ImageBlockOrTextDeserializer;
+import com.hubspot.slack.client.models.blocks.objects.ImageBlockOrText;
 
 @Immutable
 @HubSpotStyle
@@ -24,6 +24,6 @@ public interface ContextIF extends Block {
     return TYPE;
   }
 
-  @JsonDeserialize(contentUsing = ImageOrTextDeserializer.class)
-  List<ImageOrText> getElements();
+  @JsonDeserialize(contentUsing = ImageBlockOrTextDeserializer.class)
+  List<ImageBlockOrText> getElements();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/DividerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/DividerIF.java
@@ -1,0 +1,21 @@
+package com.hubspot.slack.client.models.blocks;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface DividerIF extends Block {
+  String TYPE = "divider";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/DividerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/DividerIF.java
@@ -14,7 +14,7 @@ public interface DividerIF extends Block {
   String TYPE = "divider";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/FileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/FileIF.java
@@ -19,7 +19,9 @@ public interface FileIF extends Block {
     return TYPE;
   }
 
+  @Value.Parameter
   String getExternalId();
 
+  @Value.Parameter
   String getSource();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/FileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/FileIF.java
@@ -1,0 +1,25 @@
+package com.hubspot.slack.client.models.blocks;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface FileIF extends Block {
+  String TYPE = "file";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  String getExternalId();
+
+  String getSource();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/FileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/FileIF.java
@@ -14,7 +14,7 @@ public interface FileIF extends Block {
   String TYPE = "file";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ImageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ImageIF.java
@@ -23,8 +23,10 @@ public interface ImageIF extends Block, ImageBlockOrText {
     return TYPE;
   }
 
+  @Value.Parameter
   String getImageUrl();
 
+  @Value.Parameter
   String getAltText();
 
   Optional<Text> getTitle();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ImageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ImageIF.java
@@ -1,0 +1,30 @@
+package com.hubspot.slack.client.models.blocks;
+
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ImageIF extends Block {
+  String TYPE = "image";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  String getImageUrl();
+
+  String getAltText();
+
+  Optional<Text> getTitle();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ImageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ImageIF.java
@@ -18,7 +18,7 @@ public interface ImageIF extends Block, ImageBlockOrText {
   String TYPE = "image";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ImageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ImageIF.java
@@ -8,13 +8,13 @@ import org.immutables.value.Value.Immutable;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
-import com.hubspot.slack.client.models.blocks.objects.ImageOrText;
+import com.hubspot.slack.client.models.blocks.objects.ImageBlockOrText;
 import com.hubspot.slack.client.models.blocks.objects.Text;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface ImageIF extends Block, ImageOrText {
+public interface ImageIF extends Block, ImageBlockOrText {
   String TYPE = "image";
 
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ImageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ImageIF.java
@@ -8,12 +8,13 @@ import org.immutables.value.Value.Immutable;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.ImageOrText;
 import com.hubspot.slack.client.models.blocks.objects.Text;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface ImageIF extends Block {
+public interface ImageIF extends Block, ImageOrText {
   String TYPE = "image";
 
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/InputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/InputIF.java
@@ -1,0 +1,35 @@
+package com.hubspot.slack.client.models.blocks;
+
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.elements.BlockElement;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface InputIF extends Block {
+  String TYPE = "input";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  Text getLabel();
+
+  BlockElement getElement();
+
+  Optional<Text> getHint();
+
+  @JsonProperty("optional")
+  Optional<Boolean> isOptional();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/InputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/InputIF.java
@@ -19,7 +19,7 @@ public interface InputIF extends Block {
   String TYPE = "input";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/InputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/InputIF.java
@@ -24,8 +24,10 @@ public interface InputIF extends Block {
     return TYPE;
   }
 
+  @Value.Parameter
   Text getLabel();
 
+  @Value.Parameter
   BlockElement getElement();
 
   Optional<Text> getHint();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
@@ -1,0 +1,32 @@
+package com.hubspot.slack.client.models.blocks;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.elements.BlockElement;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface SectionIF extends Block {
+  String TYPE = "section";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  Text getText();
+
+  List<Text> getFields();
+
+  Optional<BlockElement> getAccessory();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
@@ -19,7 +19,7 @@ public interface SectionIF extends Block {
   String TYPE = "section";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
@@ -24,6 +24,7 @@ public interface SectionIF extends Block {
     return TYPE;
   }
 
+  @Value.Parameter
   Text getText();
 
   List<Text> getFields();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/BlockElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/BlockElement.java
@@ -1,0 +1,29 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Button.class, name = Button.TYPE),
+    @JsonSubTypes.Type(value = DatePicker.class, name = DatePicker.TYPE),
+    @JsonSubTypes.Type(value = ChannelSelectMenu.class, name = ChannelSelectMenu.TYPE),
+    @JsonSubTypes.Type(value = ChannelsMultiSelectMenu.class, name = ChannelsMultiSelectMenu.TYPE),
+    @JsonSubTypes.Type(value = ConversationSelectMenu.class, name = ConversationSelectMenu.TYPE),
+    @JsonSubTypes.Type(value = ConversationsMultiSelectMenu.class, name = ConversationsMultiSelectMenu.TYPE),
+    @JsonSubTypes.Type(value = ExternalMultiSelectMenu.class, name = ExternalMultiSelectMenu.TYPE),
+    @JsonSubTypes.Type(value = ExternalSelectMenu.class, name = ExternalSelectMenu.TYPE),
+    @JsonSubTypes.Type(value = Image.class, name = Image.TYPE),
+    @JsonSubTypes.Type(value = OverflowMenu.class, name = OverflowMenu.TYPE),
+    @JsonSubTypes.Type(value = PlainTextInput.class, name = PlainTextInput.TYPE),
+    @JsonSubTypes.Type(value = RadioButtonGroup.class, name = RadioButtonGroup.TYPE),
+    @JsonSubTypes.Type(value = StaticMultiSelectMenu.class, name = StaticMultiSelectMenu.TYPE),
+    @JsonSubTypes.Type(value = StaticSelectMenu.class, name = StaticSelectMenu.TYPE),
+    @JsonSubTypes.Type(value = UserSelectMenu.class, name = UserSelectMenu.TYPE),
+    @JsonSubTypes.Type(value = UsersMultiSelectMenu.class, name = UsersMultiSelectMenu.TYPE),
+})
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public interface BlockElement {
+  String getType();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ButtonIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ButtonIF.java
@@ -26,7 +26,7 @@ public interface ButtonIF extends BlockElement {
 
   Text getText();
 
-  Optional<String> getActionId();
+  String getActionId();
 
   Optional<String> getUrl();
 

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ButtonIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ButtonIF.java
@@ -24,8 +24,10 @@ public interface ButtonIF extends BlockElement {
     return TYPE;
   }
 
+  @Value.Parameter
   Text getText();
 
+  @Value.Parameter
   String getActionId();
 
   Optional<String> getUrl();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ButtonIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ButtonIF.java
@@ -1,0 +1,39 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ButtonIF extends BlockElement {
+  String TYPE = "button";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  Text getText();
+
+  Optional<String> getActionId();
+
+  Optional<String> getUrl();
+
+  Optional<String> getValue();
+
+  Optional<String> getStyle();
+
+  @JsonProperty("confirm")
+  Optional<ConfirmationDialog> getConfirmationDialog();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ButtonIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ButtonIF.java
@@ -19,7 +19,7 @@ public interface ButtonIF extends BlockElement {
   String TYPE = "button";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelSelectMenuIF.java
@@ -1,0 +1,35 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ChannelSelectMenuIF extends BlockElement {
+  String TYPE = "channels_select";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  Text getPlaceholder();
+
+  String getActionId();
+
+  Optional<String> getInitialChannel();
+
+  @JsonProperty("confirm")
+  Optional<ConfirmationDialog> getConfirmationDialog();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelSelectMenuIF.java
@@ -19,7 +19,7 @@ public interface ChannelSelectMenuIF extends BlockElement {
   String TYPE = "channels_select";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelSelectMenuIF.java
@@ -28,7 +28,8 @@ public interface ChannelSelectMenuIF extends BlockElement {
 
   String getActionId();
 
-  Optional<String> getInitialChannel();
+  @JsonProperty("initial_channel")
+  Optional<String> getInitialChannelId();
 
   @JsonProperty("confirm")
   Optional<ConfirmationDialog> getConfirmationDialog();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelSelectMenuIF.java
@@ -24,8 +24,10 @@ public interface ChannelSelectMenuIF extends BlockElement {
     return TYPE;
   }
 
+  @Value.Parameter
   Text getPlaceholder();
 
+  @Value.Parameter
   String getActionId();
 
   @JsonProperty("initial_channel")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelsMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelsMultiSelectMenuIF.java
@@ -29,7 +29,8 @@ public interface ChannelsMultiSelectMenuIF extends BlockElement {
 
   String getActionId();
 
-  List<String> getInitialConversations();
+  @JsonProperty("initial_channels")
+  List<String> getInitialConversationIds();
 
   @JsonProperty("confirm")
   Optional<ConfirmationDialog> getConfirmationDialog();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelsMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelsMultiSelectMenuIF.java
@@ -20,7 +20,7 @@ public interface ChannelsMultiSelectMenuIF extends BlockElement {
   String TYPE = "multi_conversations_select";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelsMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelsMultiSelectMenuIF.java
@@ -1,0 +1,36 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ChannelsMultiSelectMenuIF extends BlockElement {
+  String TYPE = "multi_conversations_select";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  Text getPlaceholder();
+
+  String getActionId();
+
+  List<String> getInitialConversations();
+
+  @JsonProperty("confirm")
+  Optional<ConfirmationDialog> getConfirmationDialog();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelsMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelsMultiSelectMenuIF.java
@@ -25,8 +25,10 @@ public interface ChannelsMultiSelectMenuIF extends BlockElement {
     return TYPE;
   }
 
+  @Value.Parameter
   Text getPlaceholder();
 
+  @Value.Parameter
   String getActionId();
 
   @JsonProperty("initial_channels")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationSelectMenuIF.java
@@ -24,8 +24,10 @@ public interface ConversationSelectMenuIF extends BlockElement {
     return TYPE;
   }
 
+  @Value.Parameter
   Text getPlaceholder();
 
+  @Value.Parameter
   String getActionId();
 
   @JsonProperty("initial_conversation")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationSelectMenuIF.java
@@ -1,0 +1,35 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ConversationSelectMenuIF extends BlockElement {
+  String TYPE = "conversations_select";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  Text getPlaceholder();
+
+  String getActionId();
+
+  Optional<String> getInitialConversation();
+
+  @JsonProperty("confirm")
+  Optional<ConfirmationDialog> getConfirmationDialog();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationSelectMenuIF.java
@@ -28,7 +28,8 @@ public interface ConversationSelectMenuIF extends BlockElement {
 
   String getActionId();
 
-  Optional<String> getInitialConversation();
+  @JsonProperty("initial_conversation")
+  Optional<String> getInitialConversationId();
 
   @JsonProperty("confirm")
   Optional<ConfirmationDialog> getConfirmationDialog();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationSelectMenuIF.java
@@ -19,7 +19,7 @@ public interface ConversationSelectMenuIF extends BlockElement {
   String TYPE = "conversations_select";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationsMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationsMultiSelectMenuIF.java
@@ -25,8 +25,10 @@ public interface ConversationsMultiSelectMenuIF extends BlockElement {
     return TYPE;
   }
 
+  @Value.Parameter
   Text getPlaceholder();
 
+  @Value.Parameter
   String getActionId();
 
   @JsonProperty("initial_conversations")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationsMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationsMultiSelectMenuIF.java
@@ -29,7 +29,8 @@ public interface ConversationsMultiSelectMenuIF extends BlockElement {
 
   String getActionId();
 
-  List<String> getInitialChannels();
+  @JsonProperty("initial_conversations")
+  List<String> getInitialChannelIds();
 
   @JsonProperty("confirm")
   Optional<ConfirmationDialog> getConfirmationDialog();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationsMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationsMultiSelectMenuIF.java
@@ -20,7 +20,7 @@ public interface ConversationsMultiSelectMenuIF extends BlockElement {
   String TYPE = "multi_channels_select";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationsMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationsMultiSelectMenuIF.java
@@ -1,0 +1,36 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ConversationsMultiSelectMenuIF extends BlockElement {
+  String TYPE = "multi_channels_select";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  Text getPlaceholder();
+
+  String getActionId();
+
+  List<String> getInitialChannels();
+
+  @JsonProperty("confirm")
+  Optional<ConfirmationDialog> getConfirmationDialog();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/DatePickerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/DatePickerIF.java
@@ -1,0 +1,35 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface DatePickerIF extends BlockElement {
+  String TYPE = "datepicker";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  String getActionId();
+
+  Optional<Text> getPlaceholder();
+
+  Optional<String> getInitialDate();
+
+  @JsonProperty("confirm")
+  Optional<ConfirmationDialog> getConfirmationDialog();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/DatePickerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/DatePickerIF.java
@@ -21,7 +21,7 @@ public interface DatePickerIF extends BlockElement {
   String TYPE = "datepicker";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/DatePickerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/DatePickerIF.java
@@ -26,6 +26,7 @@ public interface DatePickerIF extends BlockElement {
     return TYPE;
   }
 
+  @Value.Parameter
   String getActionId();
 
   Optional<Text> getPlaceholder();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/DatePickerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/DatePickerIF.java
@@ -1,10 +1,12 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -28,7 +30,8 @@ public interface DatePickerIF extends BlockElement {
 
   Optional<Text> getPlaceholder();
 
-  Optional<String> getInitialDate();
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+  Optional<LocalDate> getInitialDate();
 
   @JsonProperty("confirm")
   Optional<ConfirmationDialog> getConfirmationDialog();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalMultiSelectMenuIF.java
@@ -21,7 +21,7 @@ public interface ExternalMultiSelectMenuIF extends BlockElement {
   String TYPE = "multi_external_select";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalMultiSelectMenuIF.java
@@ -1,0 +1,39 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
+import com.hubspot.slack.client.models.blocks.objects.OptionOrOptionGroup;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ExternalMultiSelectMenuIF extends BlockElement {
+  String TYPE = "multi_external_select";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  Text getPlaceholder();
+
+  String getActionId();
+
+  Optional<Integer> getMinQueryLength();
+
+  List<OptionOrOptionGroup> getInitialOptions();
+
+  @JsonProperty("confirm")
+  Optional<ConfirmationDialog> getConfirmationDialog();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalMultiSelectMenuIF.java
@@ -26,8 +26,10 @@ public interface ExternalMultiSelectMenuIF extends BlockElement {
     return TYPE;
   }
 
+  @Value.Parameter
   Text getPlaceholder();
 
+  @Value.Parameter
   String getActionId();
 
   Optional<Integer> getMinQueryLength();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalSelectMenuIF.java
@@ -25,8 +25,10 @@ public interface ExternalSelectMenuIF extends BlockElement {
     return TYPE;
   }
 
+  @Value.Parameter
   Text getPlaceholder();
 
+  @Value.Parameter
   String getActionId();
 
   Optional<Option> getInitialOption();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalSelectMenuIF.java
@@ -1,0 +1,38 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
+import com.hubspot.slack.client.models.blocks.objects.Option;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ExternalSelectMenuIF extends BlockElement {
+  String TYPE = "external_select";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  Text getPlaceholder();
+
+  String getActionId();
+
+  Optional<Option> getInitialOption();
+
+  Optional<Integer> getMinQueryLength();
+
+  @JsonProperty("confirm")
+  Optional<ConfirmationDialog> getConfirmationDialog();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalSelectMenuIF.java
@@ -20,7 +20,7 @@ public interface ExternalSelectMenuIF extends BlockElement {
   String TYPE = "external_select";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ImageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ImageIF.java
@@ -19,7 +19,9 @@ public interface ImageIF extends BlockElement {
     return TYPE;
   }
 
+  @Value.Parameter
   String getImageUrl();
 
+  @Value.Parameter
   String getAltText();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ImageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ImageIF.java
@@ -1,0 +1,25 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ImageIF extends BlockElement {
+  String TYPE = "image";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  String getImageUrl();
+
+  String getAltText();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ImageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ImageIF.java
@@ -14,7 +14,7 @@ public interface ImageIF extends BlockElement {
   String TYPE = "image";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/OverflowMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/OverflowMenuIF.java
@@ -25,8 +25,10 @@ public interface OverflowMenuIF extends BlockElement {
     return TYPE;
   }
 
+  @Value.Parameter
   String getActionId();
 
+  @Value.Parameter
   List<Option> getOptions();
 
   @JsonProperty("confirm")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/OverflowMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/OverflowMenuIF.java
@@ -20,7 +20,7 @@ public interface OverflowMenuIF extends BlockElement {
   String TYPE = "overflow";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/OverflowMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/OverflowMenuIF.java
@@ -1,0 +1,34 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
+import com.hubspot.slack.client.models.blocks.objects.Option;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface OverflowMenuIF extends BlockElement {
+  String TYPE = "overflow";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  String getActionId();
+
+  List<Option> getOptions();
+
+  @JsonProperty("confirm")
+  Optional<ConfirmationDialog> getConfirmationDialog();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/PlainTextInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/PlainTextInputIF.java
@@ -23,6 +23,7 @@ public interface PlainTextInputIF extends BlockElement {
     return TYPE;
   }
 
+  @Value.Parameter
   String getActionId();
 
   Optional<Text> getPlaceholder();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/PlainTextInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/PlainTextInputIF.java
@@ -1,0 +1,38 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface PlainTextInputIF extends BlockElement {
+  String TYPE = "plain_text_input";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  String getActionId();
+
+  Optional<Text> getPlaceholder();
+
+  Optional<String> getInitialValue();
+
+  @JsonProperty("multiline")
+  Optional<Boolean> isMultiline();
+
+  Optional<Integer> getMinLength();
+
+  Optional<Integer> getMaxLength();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/PlainTextInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/PlainTextInputIF.java
@@ -18,7 +18,7 @@ public interface PlainTextInputIF extends BlockElement {
   String TYPE = "plain_text_input";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/RadioButtonGroupIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/RadioButtonGroupIF.java
@@ -25,8 +25,10 @@ public interface RadioButtonGroupIF extends BlockElement {
     return TYPE;
   }
 
+  @Value.Parameter
   String getActionId();
 
+  @Value.Parameter
   List<Option> getOptions();
 
   Optional<Option> getInitialOption();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/RadioButtonGroupIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/RadioButtonGroupIF.java
@@ -20,7 +20,7 @@ public interface RadioButtonGroupIF extends BlockElement {
   String TYPE = "radio_buttons";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/RadioButtonGroupIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/RadioButtonGroupIF.java
@@ -1,0 +1,36 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
+import com.hubspot.slack.client.models.blocks.objects.Option;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface RadioButtonGroupIF extends BlockElement {
+  String TYPE = "radio_buttons";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  String getActionId();
+
+  List<Option> getOptions();
+
+  Optional<Option> getInitialOption();
+
+  @JsonProperty("confirm")
+  Optional<ConfirmationDialog> getConfirmationDialog();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticMultiSelectMenuIF.java
@@ -1,0 +1,43 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
+import com.hubspot.slack.client.models.blocks.objects.Option;
+import com.hubspot.slack.client.models.blocks.objects.OptionGroup;
+import com.hubspot.slack.client.models.blocks.objects.OptionOrOptionGroup;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface StaticMultiSelectMenuIF extends BlockElement {
+  String TYPE = "multi_static_select";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  Text getPlaceholder();
+
+  String getActionId();
+
+  List<Option> getOptions();
+
+  List<OptionGroup> getOptionGroups();
+
+  List<OptionOrOptionGroup> getInitialOptions();
+
+  @JsonProperty("confirm")
+  Optional<ConfirmationDialog> getConfirmationDialog();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticMultiSelectMenuIF.java
@@ -28,10 +28,13 @@ public interface StaticMultiSelectMenuIF extends BlockElement {
     return TYPE;
   }
 
+  @Value.Parameter
   Text getPlaceholder();
 
+  @Value.Parameter
   String getActionId();
 
+  @Value.Parameter
   List<Option> getOptions();
 
   List<OptionGroup> getOptionGroups();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticMultiSelectMenuIF.java
@@ -23,7 +23,7 @@ public interface StaticMultiSelectMenuIF extends BlockElement {
   String TYPE = "multi_static_select";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticSelectMenuIF.java
@@ -23,7 +23,7 @@ public interface StaticSelectMenuIF extends BlockElement {
   String TYPE = "static_select";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticSelectMenuIF.java
@@ -28,10 +28,13 @@ public interface StaticSelectMenuIF extends BlockElement {
     return TYPE;
   }
 
+  @Value.Parameter
   Text getPlaceholder();
 
+  @Value.Parameter
   String getActionId();
 
+  @Value.Parameter
   List<Option> getOptions();
 
   List<OptionGroup> getOptionGroups();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticSelectMenuIF.java
@@ -1,0 +1,43 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
+import com.hubspot.slack.client.models.blocks.objects.Option;
+import com.hubspot.slack.client.models.blocks.objects.OptionGroup;
+import com.hubspot.slack.client.models.blocks.objects.OptionOrOptionGroup;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface StaticSelectMenuIF extends BlockElement {
+  String TYPE = "static_select";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  Text getPlaceholder();
+
+  String getActionId();
+
+  List<Option> getOptions();
+
+  List<OptionGroup> getOptionGroups();
+
+  Optional<OptionOrOptionGroup> getInitialOption();
+
+  @JsonProperty("confirm")
+  Optional<ConfirmationDialog> getConfirmationDialog();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UserSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UserSelectMenuIF.java
@@ -19,7 +19,7 @@ public interface UserSelectMenuIF extends BlockElement {
   String TYPE = "users_select";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UserSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UserSelectMenuIF.java
@@ -28,7 +28,8 @@ public interface UserSelectMenuIF extends BlockElement {
 
   String getActionId();
 
-  Optional<String> getInitialUser();
+  @JsonProperty("initial_user")
+  Optional<String> getInitialUserId();
 
   @JsonProperty("confirm")
   Optional<ConfirmationDialog> getConfirmationDialog();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UserSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UserSelectMenuIF.java
@@ -24,8 +24,10 @@ public interface UserSelectMenuIF extends BlockElement {
     return TYPE;
   }
 
+  @Value.Parameter
   Text getPlaceholder();
 
+  @Value.Parameter
   String getActionId();
 
   @JsonProperty("initial_user")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UserSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UserSelectMenuIF.java
@@ -1,0 +1,35 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface UserSelectMenuIF extends BlockElement {
+  String TYPE = "users_select";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  Text getPlaceholder();
+
+  String getActionId();
+
+  Optional<String> getInitialUser();
+
+  @JsonProperty("confirm")
+  Optional<ConfirmationDialog> getConfirmationDialog();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UsersMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UsersMultiSelectMenuIF.java
@@ -1,0 +1,36 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface UsersMultiSelectMenuIF extends BlockElement {
+  String TYPE = "multi_users_select";
+
+  @Override
+  @Value.Default
+  default String getType() {
+    return TYPE;
+  }
+
+  Text getPlaceholder();
+
+  String getActionId();
+
+  List<String> getInitialUsers();
+
+  @JsonProperty("confirm")
+  Optional<ConfirmationDialog> getConfirmationDialog();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UsersMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UsersMultiSelectMenuIF.java
@@ -20,7 +20,7 @@ public interface UsersMultiSelectMenuIF extends BlockElement {
   String TYPE = "multi_users_select";
 
   @Override
-  @Value.Default
+  @Value.Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UsersMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UsersMultiSelectMenuIF.java
@@ -25,8 +25,10 @@ public interface UsersMultiSelectMenuIF extends BlockElement {
     return TYPE;
   }
 
+  @Value.Parameter
   Text getPlaceholder();
 
+  @Value.Parameter
   String getActionId();
 
   @JsonProperty("initial_users")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UsersMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UsersMultiSelectMenuIF.java
@@ -29,7 +29,8 @@ public interface UsersMultiSelectMenuIF extends BlockElement {
 
   String getActionId();
 
-  List<String> getInitialUsers();
+  @JsonProperty("initial_users")
+  List<String> getInitialUserIds();
 
   @JsonProperty("confirm")
   Optional<ConfirmationDialog> getConfirmationDialog();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/json/ImageBlockOrTextDeserializer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/json/ImageBlockOrTextDeserializer.java
@@ -8,17 +8,18 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.hubspot.slack.client.models.blocks.Image;
+import com.hubspot.slack.client.models.blocks.objects.ImageBlockOrText;
 import com.hubspot.slack.client.models.blocks.objects.Text;
 
-public class ImageOrTextDeserializer extends StdDeserializer<Object> {
+public class ImageBlockOrTextDeserializer extends StdDeserializer<ImageBlockOrText> {
   private static final String TYPE_FIELD = "type";
 
-  protected ImageOrTextDeserializer() {
-    super(Object.class);
+  protected ImageBlockOrTextDeserializer() {
+    super(ImageBlockOrText.class);
   }
 
   @Override
-  public Object deserialize(JsonParser p, DeserializationContext context) throws IOException {
+  public ImageBlockOrText deserialize(JsonParser p, DeserializationContext context) throws IOException {
     ObjectCodec codec = p.getCodec();
     JsonNode node = codec.readTree(p);
 

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/json/ImageOrTextDeserializer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/json/ImageOrTextDeserializer.java
@@ -1,0 +1,32 @@
+package com.hubspot.slack.client.models.blocks.json;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.hubspot.slack.client.models.blocks.Image;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+
+public class ImageOrTextDeserializer extends StdDeserializer<Object> {
+  private static final String TYPE_FIELD = "type";
+
+  protected ImageOrTextDeserializer() {
+    super(Object.class);
+  }
+
+  @Override
+  public Object deserialize(JsonParser p, DeserializationContext context) throws IOException {
+    ObjectCodec codec = p.getCodec();
+    JsonNode node = codec.readTree(p);
+
+    String type = node.get(TYPE_FIELD).asText();
+    if (Image.TYPE.equals(type)) {
+      return codec.treeToValue(node, Image.class);
+    }
+
+    return codec.treeToValue(node, Text.class);
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/CompositionObject.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/CompositionObject.java
@@ -1,0 +1,7 @@
+package com.hubspot.slack.client.models.blocks.objects;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public interface CompositionObject {
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/ConfirmationDialogIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/ConfirmationDialogIF.java
@@ -1,5 +1,6 @@
 package com.hubspot.slack.client.models.blocks.objects;
 
+import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -11,13 +12,17 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ConfirmationDialogIF extends OptionOrOptionGroup {
+  @Value.Parameter
   Text getTitle();
 
+  @Value.Parameter
   Text getText();
 
   @JsonProperty("confirm")
+  @Value.Parameter
   Text getConfirmButtonText();
 
   @JsonProperty("deny")
+  @Value.Parameter
   Text getDenyButtonText();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/ConfirmationDialogIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/ConfirmationDialogIF.java
@@ -1,0 +1,23 @@
+package com.hubspot.slack.client.models.blocks.objects;
+
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ConfirmationDialogIF extends OptionOrOptionGroup {
+  Text getTitle();
+
+  Text getText();
+
+  @JsonProperty("confirm")
+  Text getConfirmButtonText();
+
+  @JsonProperty("deny")
+  Text getDenyButtonText();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/ImageBlockOrText.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/ImageBlockOrText.java
@@ -1,4 +1,4 @@
 package com.hubspot.slack.client.models.blocks.objects;
 
-public interface ImageOrText {
+public interface ImageBlockOrText {
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/ImageOrText.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/ImageOrText.java
@@ -1,0 +1,4 @@
+package com.hubspot.slack.client.models.blocks.objects;
+
+public interface ImageOrText {
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionGroupIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionGroupIF.java
@@ -2,6 +2,7 @@ package com.hubspot.slack.client.models.blocks.objects;
 
 import java.util.List;
 
+import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
@@ -12,7 +13,9 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 public interface OptionGroupIF extends OptionOrOptionGroup {
+  @Value.Parameter
   Text getLabel();
 
+  @Value.Parameter
   List<Option> getOptions();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionGroupIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionGroupIF.java
@@ -1,0 +1,18 @@
+package com.hubspot.slack.client.models.blocks.objects;
+
+import java.util.List;
+
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface OptionGroupIF extends OptionOrOptionGroup {
+  Text getLabel();
+
+  List<Option> getOptions();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionIF.java
@@ -2,6 +2,7 @@ package com.hubspot.slack.client.models.blocks.objects;
 
 import java.util.Optional;
 
+import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
@@ -12,8 +13,10 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 public interface OptionIF extends OptionOrOptionGroup{
+  @Value.Parameter
   Text getText();
 
+  @Value.Parameter
   String getValue();
 
   Optional<String> getUrl();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionIF.java
@@ -1,0 +1,20 @@
+package com.hubspot.slack.client.models.blocks.objects;
+
+import java.util.Optional;
+
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface OptionIF extends OptionOrOptionGroup{
+  Text getText();
+
+  String getValue();
+
+  Optional<String> getUrl();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionOrOptionGroup.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionOrOptionGroup.java
@@ -1,0 +1,4 @@
+package com.hubspot.slack.client.models.blocks.objects;
+
+public interface OptionOrOptionGroup extends CompositionObject {
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/TextIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/TextIF.java
@@ -12,7 +12,7 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface TextIF extends CompositionObject, ImageOrText {
+public interface TextIF extends CompositionObject, ImageBlockOrText {
   TextType getType();
 
   Optional<String> getText();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/TextIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/TextIF.java
@@ -1,0 +1,25 @@
+package com.hubspot.slack.client.models.blocks.objects;
+
+import java.util.Optional;
+
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface TextIF extends CompositionObject {
+  TextType getType();
+
+  Optional<String> getText();
+
+  @JsonProperty("emoji")
+  Optional<Boolean> isEmoji();
+
+  @JsonProperty("verbatim")
+  Optional<Boolean> isVerbatim();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/TextIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/TextIF.java
@@ -12,7 +12,7 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface TextIF extends CompositionObject {
+public interface TextIF extends CompositionObject, ImageOrText {
   TextType getType();
 
   Optional<String> getText();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/TextIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/TextIF.java
@@ -2,6 +2,7 @@ package com.hubspot.slack.client.models.blocks.objects;
 
 import java.util.Optional;
 
+import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,9 +14,11 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 public interface TextIF extends CompositionObject, ImageBlockOrText {
+  @Value.Parameter
   TextType getType();
 
-  Optional<String> getText();
+  @Value.Parameter
+  String getText();
 
   @JsonProperty("emoji")
   Optional<Boolean> isEmoji();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/TextType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/TextType.java
@@ -1,0 +1,11 @@
+package com.hubspot.slack.client.models.blocks.objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum TextType {
+  @JsonProperty("plain_text")
+  PLAIN_TEXT,
+
+  @JsonProperty("mrkdwn")
+  MARKDOWN;
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/blocks/BlockSerializationTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/blocks/BlockSerializationTest.java
@@ -1,0 +1,31 @@
+package com.hubspot.slack.client.models.blocks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hubspot.slack.client.jackson.ObjectMapperUtils;
+import com.hubspot.slack.client.models.JsonLoader;
+
+public class BlockSerializationTest {
+
+  private ObjectMapper objectMapper;
+
+  @Before
+  public void setup() {
+    objectMapper = ObjectMapperUtils.mapper();
+  }
+
+  @Test
+  public void testBlockSerialization() throws IOException {
+    String rawJson = JsonLoader.loadJsonFromFile("blocks.json");
+    Block[] blocks = objectMapper.readValue(rawJson, Block[].class);
+    assertThat(blocks).hasSize(9);
+    String generatedJson = objectMapper.writeValueAsString(blocks);
+    assertThat(objectMapper.readTree(rawJson)).isEqualTo(objectMapper.readTree(generatedJson));
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/blocks/elements/BlockElementSerializationTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/blocks/elements/BlockElementSerializationTest.java
@@ -1,0 +1,31 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hubspot.slack.client.jackson.ObjectMapperUtils;
+import com.hubspot.slack.client.models.JsonLoader;
+
+public class BlockElementSerializationTest {
+
+  private ObjectMapper objectMapper;
+
+  @Before
+  public void setup() {
+    objectMapper = ObjectMapperUtils.mapper();
+  }
+
+  @Test
+  public void testBlockSerialization() throws IOException {
+    String rawJson = JsonLoader.loadJsonFromFile("block_elements.json");
+    BlockElement[] blockElements = objectMapper.readValue(rawJson, BlockElement[].class);
+//    assertThat(blockElements).hasSize(9);
+    String generatedJson = objectMapper.writeValueAsString(blockElements);
+    assertThat(objectMapper.readTree(rawJson)).isEqualTo(objectMapper.readTree(generatedJson));
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/blocks/elements/BlockElementSerializationTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/blocks/elements/BlockElementSerializationTest.java
@@ -24,7 +24,6 @@ public class BlockElementSerializationTest {
   public void testBlockSerialization() throws IOException {
     String rawJson = JsonLoader.loadJsonFromFile("block_elements.json");
     BlockElement[] blockElements = objectMapper.readValue(rawJson, BlockElement[].class);
-//    assertThat(blockElements).hasSize(9);
     String generatedJson = objectMapper.writeValueAsString(blockElements);
     assertThat(objectMapper.readTree(rawJson)).isEqualTo(objectMapper.readTree(generatedJson));
   }

--- a/slack-base/src/test/resources/block_elements.json
+++ b/slack-base/src/test/resources/block_elements.json
@@ -1,0 +1,265 @@
+[
+  {
+    "type": "button",
+    "text": {
+      "type": "plain_text",
+      "text": "Click Me"
+    },
+    "value": "click_me_123",
+    "action_id": "button"
+  },
+  {
+    "type": "button",
+    "text": {
+      "type": "plain_text",
+      "text": "Save"
+    },
+    "style": "primary",
+    "value": "click_me_123",
+    "action_id": "button"
+  },
+  {
+    "type": "button",
+    "text": {
+      "type": "plain_text",
+      "text": "Link Button"
+    },
+    "url": "https://api.slack.com/block-kit"
+  },
+  {
+    "type": "datepicker",
+    "action_id": "datepicker123",
+    "initial_date": "1990-04-28",
+    "placeholder": {
+      "type": "plain_text",
+      "text": "Select a date"
+    }
+  },
+  {
+    "type": "image",
+    "image_url": "http://placekitten.com/700/500",
+    "alt_text": "Multiple cute kittens"
+  },
+  {
+    "action_id": "text1234",
+    "type": "multi_static_select",
+    "placeholder": {
+      "type": "plain_text",
+      "text": "Select items"
+    },
+    "options": [
+      {
+        "text": {
+          "type": "plain_text",
+          "text": "*this is plain_text text*"
+        },
+        "value": "value-0"
+      },
+      {
+        "text": {
+          "type": "plain_text",
+          "text": "*this is plain_text text*"
+        },
+        "value": "value-1"
+      },
+      {
+        "text": {
+          "type": "plain_text",
+          "text": "*this is plain_text text*"
+        },
+        "value": "value-2"
+      }
+    ]
+  },
+  {
+    "action_id": "text1234",
+    "type": "multi_external_select",
+    "placeholder": {
+      "type": "plain_text",
+      "text": "Select items"
+    },
+    "min_query_length": 3
+  },
+  {
+    "action_id": "text1234",
+    "type": "multi_users_select",
+    "placeholder": {
+      "type": "plain_text",
+      "text": "Select users"
+    }
+  },
+  {
+    "action_id": "text1234",
+    "type": "multi_conversations_select",
+    "placeholder": {
+      "type": "plain_text",
+      "text": "Select conversations"
+    }
+  },
+  {
+    "action_id": "text1234",
+    "type": "multi_channels_select",
+    "placeholder": {
+      "type": "plain_text",
+      "text": "Select channels"
+    }
+  },
+  {
+    "type": "overflow",
+    "options": [
+      {
+        "text": {
+          "type": "plain_text",
+          "text": "*this is plain_text text*"
+        },
+        "value": "value-0"
+      },
+      {
+        "text": {
+          "type": "plain_text",
+          "text": "*this is plain_text text*"
+        },
+        "value": "value-1"
+      },
+      {
+        "text": {
+          "type": "plain_text",
+          "text": "*this is plain_text text*"
+        },
+        "value": "value-2"
+      },
+      {
+        "text": {
+          "type": "plain_text",
+          "text": "*this is plain_text text*"
+        },
+        "value": "value-3"
+      },
+      {
+        "text": {
+          "type": "plain_text",
+          "text": "*this is plain_text text*"
+        },
+        "value": "value-4"
+      }
+    ],
+    "action_id": "overflow"
+  },
+  {
+    "type": "plain_text_input",
+    "action_id": "plain_input",
+    "placeholder": {
+      "type": "plain_text",
+      "text": "Enter some plain text"
+    }
+  },
+  {
+    "type": "radio_buttons",
+    "action_id": "this_is_an_action_id",
+    "initial_option": {
+      "value": "A1",
+      "text": {
+        "type": "plain_text",
+        "text": "Radio 1"
+      }
+    },
+    "options": [
+      {
+        "value": "A1",
+        "text": {
+          "type": "plain_text",
+          "text": "Radio 1"
+        }
+      },
+      {
+        "value": "A2",
+        "text": {
+          "type": "plain_text",
+          "text": "Radio 2"
+        }
+      }
+    ]
+  },
+  {
+    "action_id": "text1234",
+    "type": "static_select",
+    "placeholder": {
+      "type": "plain_text",
+      "text": "Select an item"
+    },
+    "options": [
+      {
+        "text": {
+          "type": "plain_text",
+          "text": "*this is plain_text text*"
+        },
+        "value": "value-0"
+      },
+      {
+        "text": {
+          "type": "plain_text",
+          "text": "*this is plain_text text*"
+        },
+        "value": "value-1"
+      },
+      {
+        "text": {
+          "type": "plain_text",
+          "text": "*this is plain_text text*"
+        },
+        "value": "value-2"
+      }
+    ]
+  },
+  {
+    "action_id": "text1234",
+    "type": "external_select",
+    "placeholder": {
+      "type": "plain_text",
+      "text": "Select an item"
+    },
+    "min_query_length": 3
+  },
+  {
+    "action_id": "text1234",
+    "type": "users_select",
+    "placeholder": {
+      "type": "plain_text",
+      "text": "Select an item"
+    }
+  },
+  {
+    "action_id": "text1234",
+    "type": "conversations_select",
+    "placeholder": {
+      "type": "plain_text",
+      "text": "Select an item"
+    }
+  },
+  {
+    "action_id": "text1234",
+    "type": "channels_select",
+    "placeholder": {
+      "type": "plain_text",
+      "text": "Select an item"
+    },
+    "confirm": {
+      "title": {
+        "type": "plain_text",
+        "text": "Are you sure?"
+      },
+      "text": {
+        "type": "mrkdwn",
+        "text": "Wouldn't you prefer a good game of _chess_?"
+      },
+      "confirm": {
+        "type": "plain_text",
+        "text": "Do it"
+      },
+      "deny": {
+        "type": "plain_text",
+        "text": "Stop, I've changed my mind!"
+      }
+    }
+  }
+]

--- a/slack-base/src/test/resources/block_elements.json
+++ b/slack-base/src/test/resources/block_elements.json
@@ -24,7 +24,8 @@
       "type": "plain_text",
       "text": "Link Button"
     },
-    "url": "https://api.slack.com/block-kit"
+    "url": "https://api.slack.com/block-kit",
+    "action_id": "button"
   },
   {
     "type": "datepicker",

--- a/slack-base/src/test/resources/blocks.json
+++ b/slack-base/src/test/resources/blocks.json
@@ -1,0 +1,193 @@
+[
+  {
+    "type": "section",
+    "text": {
+      "type": "mrkdwn",
+      "text": "A message *with some bold text* and _some italicized text_."
+    }
+  },
+  {
+    "type": "section",
+    "text": {
+      "text": "A message *with some bold text* and _some italicized text_.",
+      "type": "mrkdwn"
+    },
+    "fields": [
+      {
+        "type": "mrkdwn",
+        "text": "High"
+      },
+      {
+        "type": "plain_text",
+        "emoji": true,
+        "text": "String"
+      }
+    ]
+  },
+  {
+    "type": "section",
+    "text": {
+      "text": "*Sally* has requested you set the deadline for the Nano launch project",
+      "type": "mrkdwn"
+    },
+    "accessory": {
+      "type": "datepicker",
+      "action_id": "datepicker123",
+      "initial_date": "1990-04-28",
+      "placeholder": {
+        "type": "plain_text",
+        "text": "Select a date"
+      }
+    }
+  },
+  {
+    "type": "divider"
+  },
+  {
+    "type": "image",
+    "title": {
+      "type": "plain_text",
+      "text": "Please enjoy this photo of a kitten"
+    },
+    "block_id": "image4",
+    "image_url": "http://placekitten.com/500/500",
+    "alt_text": "An incredibly cute kitten."
+  },
+  {
+    "type": "actions",
+    "block_id": "actions1",
+    "elements": [
+      {
+        "type": "static_select",
+        "placeholder": {
+          "type": "plain_text",
+          "text": "Which witch is the witchiest witch?"
+        },
+        "action_id": "select_2",
+        "options": [
+          {
+            "text": {
+              "type": "plain_text",
+              "text": "Matilda"
+            },
+            "value": "matilda"
+          },
+          {
+            "text": {
+              "type": "plain_text",
+              "text": "Glinda"
+            },
+            "value": "glinda"
+          },
+          {
+            "text": {
+              "type": "plain_text",
+              "text": "Granny Weatherwax"
+            },
+            "value": "grannyWeatherwax"
+          },
+          {
+            "text": {
+              "type": "plain_text",
+              "text": "Hermione"
+            },
+            "value": "hermione"
+          }
+        ]
+      },
+      {
+        "type": "button",
+        "text": {
+          "type": "plain_text",
+          "text": "Cancel"
+        },
+        "value": "cancel",
+        "action_id": "button_1"
+      }
+    ]
+  },
+  {
+    "type": "actions",
+    "block_id": "actionblock789",
+    "elements": [
+      {
+        "type": "datepicker",
+        "action_id": "datepicker123",
+        "initial_date": "1990-04-28",
+        "placeholder": {
+          "type": "plain_text",
+          "text": "Select a date"
+        }
+      },
+      {
+        "type": "overflow",
+        "options": [
+          {
+            "text": {
+              "type": "plain_text",
+              "text": "*this is plain_text text*"
+            },
+            "value": "value-0"
+          },
+          {
+            "text": {
+              "type": "plain_text",
+              "text": "*this is plain_text text*"
+            },
+            "value": "value-1"
+          },
+          {
+            "text": {
+              "type": "plain_text",
+              "text": "*this is plain_text text*"
+            },
+            "value": "value-2"
+          },
+          {
+            "text": {
+              "type": "plain_text",
+              "text": "*this is plain_text text*"
+            },
+            "value": "value-3"
+          },
+          {
+            "text": {
+              "type": "plain_text",
+              "text": "*this is plain_text text*"
+            },
+            "value": "value-4"
+          }
+        ],
+        "action_id": "overflow"
+      },
+      {
+        "type": "button",
+        "text": {
+          "type": "plain_text",
+          "text": "Click Me"
+        },
+        "value": "click_me_123",
+        "action_id": "button"
+      }
+    ]
+  },
+  {
+    "type": "context",
+    "elements": [
+      {
+        "type": "image",
+        "image_url": "https://image.freepik.com/free-photo/red-drawing-pin_1156-445.jpg",
+        "alt_text": "images"
+      },
+      {
+        "type": "mrkdwn",
+        "text": "Location: **Dogpatch**"
+      }
+    ]
+  },
+  {
+    "type": "file",
+    "external_id": "ABCD1",
+    "source": "remote"
+  }
+]

--- a/slack-java-client-examples/src/main/java/com/hubspot/slack/client/examples/Blocks.java
+++ b/slack-java-client-examples/src/main/java/com/hubspot/slack/client/examples/Blocks.java
@@ -1,0 +1,72 @@
+package com.hubspot.slack.client.examples;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+
+import com.hubspot.slack.client.models.blocks.Context;
+import com.hubspot.slack.client.models.blocks.Divider;
+import com.hubspot.slack.client.models.blocks.Section;
+import com.hubspot.slack.client.models.blocks.elements.Button;
+import com.hubspot.slack.client.models.blocks.elements.StaticSelectMenu;
+import com.hubspot.slack.client.models.blocks.objects.Option;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+import com.hubspot.slack.client.models.blocks.objects.TextType;
+
+public class Blocks {
+  private Blocks() {
+  }
+
+  public static Section markdownSection(String text) {
+    return Section.builder()
+        .setText(markdownText(text))
+        .build();
+  }
+
+  public static Context markdownContext(String text) {
+    return Context.builder()
+        .setElements(Collections.singleton(markdownText(text)))
+        .build();
+  }
+
+  public static Divider divider() {
+    return Divider.builder().build();
+  }
+
+  public static Button plainTextButton(String text) {
+    return Button.builder()
+        .setActionId(UUID.randomUUID().toString())
+        .setText(plainText(text))
+        .build();
+  }
+
+  public static Text markdownText(String text) {
+    return Text.builder()
+        .setText(text)
+        .setType(TextType.MARKDOWN)
+        .build();
+  }
+
+  public static StaticSelectMenu staticSelectMenu(String placeholder, Option... options) {
+    return StaticSelectMenu.builder()
+        .setActionId(UUID.randomUUID().toString())
+        .setPlaceholder(plainText(placeholder))
+        .setOptions(Arrays.asList(options))
+        .build();
+  }
+
+  public static Option option(String text, String value) {
+    return Option.builder()
+        .setText(plainText(text))
+        .setValue(value)
+        .build();
+  }
+
+  public static Text plainText(String text) {
+    return Text.builder()
+        .setText(text)
+        .setType(TextType.PLAIN_TEXT)
+        .build();
+  }
+
+}

--- a/slack-java-client-examples/src/main/java/com/hubspot/slack/client/examples/Blocks.java
+++ b/slack-java-client-examples/src/main/java/com/hubspot/slack/client/examples/Blocks.java
@@ -18,15 +18,11 @@ public class Blocks {
   }
 
   public static Section markdownSection(String text) {
-    return Section.builder()
-        .setText(markdownText(text))
-        .build();
+    return Section.of(markdownText(text));
   }
 
   public static Context markdownContext(String text) {
-    return Context.builder()
-        .setElements(Collections.singleton(markdownText(text)))
-        .build();
+    return Context.of(Collections.singleton(markdownText(text)));
   }
 
   public static Divider divider() {
@@ -34,39 +30,22 @@ public class Blocks {
   }
 
   public static Button plainTextButton(String text) {
-    return Button.builder()
-        .setActionId(UUID.randomUUID().toString())
-        .setText(plainText(text))
-        .build();
+    return Button.of(plainText(text), UUID.randomUUID().toString());
   }
 
   public static Text markdownText(String text) {
-    return Text.builder()
-        .setText(text)
-        .setType(TextType.MARKDOWN)
-        .build();
+    return Text.of(TextType.MARKDOWN, text);
   }
 
   public static StaticSelectMenu staticSelectMenu(String placeholder, Option... options) {
-    return StaticSelectMenu.builder()
-        .setActionId(UUID.randomUUID().toString())
-        .setPlaceholder(plainText(placeholder))
-        .setOptions(Arrays.asList(options))
-        .build();
+    return StaticSelectMenu.of(plainText(placeholder), UUID.randomUUID().toString(), Arrays.asList(options));
   }
 
   public static Option option(String text, String value) {
-    return Option.builder()
-        .setText(plainText(text))
-        .setValue(value)
-        .build();
+    return Option.of(plainText(text), value);
   }
 
   public static Text plainText(String text) {
-    return Text.builder()
-        .setText(text)
-        .setType(TextType.PLAIN_TEXT)
-        .build();
+    return Text.of(TextType.PLAIN_TEXT, text);
   }
-
 }

--- a/slack-java-client-examples/src/main/java/com/hubspot/slack/client/examples/PostABlockKitMessage.java
+++ b/slack-java-client-examples/src/main/java/com/hubspot/slack/client/examples/PostABlockKitMessage.java
@@ -1,0 +1,58 @@
+package com.hubspot.slack.client.examples;
+
+import java.util.Arrays;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.hubspot.algebra.Result;
+import com.hubspot.slack.client.SlackClient;
+import com.hubspot.slack.client.methods.params.chat.ChatPostMessageParams;
+import com.hubspot.slack.client.models.response.SlackError;
+import com.hubspot.slack.client.models.response.chat.ChatPostMessageResponse;
+
+public class PostABlockKitMessage {
+  private static final Logger LOG = LoggerFactory.getLogger(PostABlockKitMessage.class);
+
+  public static void main(String[] args) {
+    SlackClient client = BasicRuntimeConfig.getClient();
+
+    ChatPostMessageResponse response = messageChannel("fake channel id", client);
+    LOG.info("Got: {}", response);
+  }
+
+  public static ChatPostMessageResponse messageChannel(String channelToPostIn, SlackClient slackClient) {
+    Result<ChatPostMessageResponse, SlackError> postResult = slackClient.postMessage(
+        ChatPostMessageParams.builder()
+            .setText("Here is an example message with blocks:")
+            .setChannelId(channelToPostIn)
+            .setBlocks(Arrays.asList(
+                Blocks.markdownSection(":newspaper:  *Paper Company Newsletter*  :newspaper:"),
+                Blocks.markdownContext("*November 12, 2019*  |  Sales Team Announcements"),
+                Blocks.divider(),
+                Blocks.markdownSection(":loud_sound: *IN CASE YOU MISSED IT* :loud_sound:"),
+                Blocks.markdownSection("Replay our screening of *Threat Level Midnight* and pick up a copy of the DVD to give to your customers at the front desk.")
+                    .withAccessory(Blocks.plainTextButton("Watch Now")),
+                Blocks.markdownSection("The *2019 Dundies* happened. \nAwards were given, heroes were recognized. \nCheck out *#dundies-2019* to see who won awards."),
+                Blocks.divider(),
+                Blocks.markdownSection(":calendar: |   *UPCOMING EVENTS*  | :calendar:"),
+                Blocks.markdownSection("`11/20-11/22` *Beet the Competition* _ annual retreat at Schrute Farms_")
+                    .withAccessory(Blocks.plainTextButton("RSVP")),
+                Blocks.markdownSection("`12/01` *Toby's Going Away Party* at _Benihana_")
+                    .withAccessory(Blocks.plainTextButton("Learn More")),
+                Blocks.markdownSection("`11/13` :pretzel: *Pretzel Day* :pretzel: at _Scranton Office_")
+                    .withAccessory(Blocks.plainTextButton("RSVP")),
+                Blocks.divider(),
+                Blocks.markdownSection(":calendar: |   *PAST EVENTS*  | :calendar:"),
+                Blocks.markdownSection("`10/21` *Conference Room Meeting*")
+                    .withAccessory(Blocks.staticSelectMenu("Manage",
+                        Blocks.option("Edit it", "value=0"),
+                        Blocks.option("Read it", "value=1"),
+                        Blocks.option("Save it", "value=2"))),
+                Blocks.divider()
+            )).build()
+    ).join();
+
+    return postResult.unwrapOrElseThrow(); // release failure here as a RTE
+  }
+}


### PR DESCRIPTION
Adds support for [Block Kit](https://api.slack.com/reference/block-kit/blocks) when sending messages to slack.

Add example `PostABlockKitMessage` client is added as an example of how to send messages with block components.
