### PR TITLE
Messages from search may not have a user

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/MessageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/MessageIF.java
@@ -16,7 +16,7 @@ public interface MessageIF {
   String getTeam();
   SlackChannel getChannel();
 
-  String getUser();
+  Optional<String> getUser();
   String getUsername();
 
   @JsonProperty("ts")


### PR DESCRIPTION
Fixes #109. Tested in production.
However, it's potentially a breaking change.
Please advise if some extra measures should be taken.