### PR TITLE
User profile fields

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/users/ProfileFieldIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/users/ProfileFieldIF.java
@@ -1,5 +1,7 @@
 package com.hubspot.slack.client.models.users;
 
+import java.util.Optional;
+
 import org.immutables.value.Value.Immutable;
 
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -10,5 +12,5 @@ public interface ProfileFieldIF {
 
   String getValue();
 
-  String getAlt();
+  Optional<String> getAlt();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/users/ProfileFieldIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/users/ProfileFieldIF.java
@@ -1,0 +1,14 @@
+package com.hubspot.slack.client.models.users;
+
+import org.immutables.value.Value.Immutable;
+
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+public interface ProfileFieldIF {
+
+  String getValue();
+
+  String getAlt();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/users/UserProfileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/users/UserProfileIF.java
@@ -1,5 +1,6 @@
 package com.hubspot.slack.client.models.users;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.immutables.value.Value.Immutable;
@@ -27,6 +28,9 @@ public interface UserProfileIF {
   Optional<String> getTitle();
   Optional<String> getPhone();
   Optional<String> getSkype();
+
+  // Extra custom fields set by your workspace admin
+  Optional<Map<String, String>> getFields();
 
   @JsonProperty("team")
   Optional<String> getTeamId();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/users/UserProfileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/users/UserProfileIF.java
@@ -30,7 +30,7 @@ public interface UserProfileIF {
   Optional<String> getSkype();
 
   // Extra custom fields set by your workspace admin
-  Optional<Map<String, String>> getFields();
+  Optional<Map<String, ProfileField>> getFields();
 
   @JsonProperty("team")
   Optional<String> getTeamId();

--- a/slack-base/src/test/resources/deleted_slack_user.json
+++ b/slack-base/src/test/resources/deleted_slack_user.json
@@ -22,8 +22,8 @@
     "image_1024": null,
     "fields": {
       "X000000000": {
-        "value": "",
-        "alt": ""
+        "value": "test123",
+        "alt": "alt"
       }
     }
   },

--- a/slack-base/src/test/resources/deleted_slack_user.json
+++ b/slack-base/src/test/resources/deleted_slack_user.json
@@ -19,7 +19,13 @@
     "image_72": "https:\/\/a.slack-edge.com\/0180\/img\/slackbot_72.png",
     "image_192": "https:\/\/a.slack-edge.com\/66f9\/img\/slackbot_192.png",
     "image_512": "https:\/\/a.slack-edge.com\/1801\/img\/slackbot_512.png",
-    "image_1024": null
+    "image_1024": null,
+    "fields": {
+      "X000000000": {
+        "value": "",
+        "alt": ""
+      }
+    }
   },
   "color": "757575",
   "team_id": "redacted",


### PR DESCRIPTION
These don't appear to be documented but do appear to exist. AFAICT its a `Map<String, ProfileField>`.

For  us for example we've got the actual username of the user in here, as well as other visible / non-visible custom profile data. 

Example redacted data:
```json
{
  "fields": {
    "X000000000": {
       "value": "",
       "alt": ""
     },
  }
}
```