### PR TITLE
Add APP_MENTION event type

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventType.java
@@ -13,6 +13,7 @@ import com.hubspot.slack.client.models.events.user.SlackUserChangeEvent;
 
 public enum SlackEventType {
 
+  APP_MENTION(SlackEventMessage.class),
   APP_UNINSTALLED,
   CHANNEL_ARCHIVE(SlackChannelArchiveEvent.class),
   CHANNEL_CREATED(SlackChannelCreatedEvent.class),

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/events/json/EventDeserializerTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/events/json/EventDeserializerTest.java
@@ -19,6 +19,12 @@ import com.hubspot.slack.client.models.events.user.SlackUserChangeEvent;
 
 public class EventDeserializerTest {
   @Test
+  public void itCanDeserAppMentionMessage() throws IOException {
+    SlackEvent event = fetchAndDeserializeSlackEvent("app_mention_message.json");
+    assertThat(event.getType()).isEqualTo(SlackEventType.APP_MENTION);
+  }
+
+  @Test
   public void itCanDeserMessageChanged1() throws IOException {
     SlackEvent event = fetchAndDeserializeSlackEvent("message_change1.json");
     assertThat(event.getType()).isEqualTo(SlackEventType.MESSAGE);

--- a/slack-base/src/test/resources/app_mention_message.json
+++ b/slack-base/src/test/resources/app_mention_message.json
@@ -1,0 +1,42 @@
+{
+  "token": "redacted",
+  "team_id": "redacted",
+  "api_app_id": "redacted",
+  "event": {
+    "client_msg_id": "bf714cbe-cc7b-4c0b-a9fc-87ca63c6ee29",
+    "type": "app_mention",
+    "text": "<@UA22B84GG> hey",
+    "user": "UA227N1MW",
+    "ts": "1575305487.002200",
+    "team": "TA26P468Z",
+    "blocks": [
+      {
+        "type": "rich_text",
+        "block_id": "GxKF",
+        "elements": [
+          {
+            "type": "rich_text_section",
+            "elements": [
+              {
+                "type": "user",
+                "user_id": "UA22B84GG"
+              },
+              {
+                "type": "text",
+                "text": " help"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "channel": "CA3KDNNVC",
+    "event_ts": "1575305487.002200"
+  },
+  "type": "event_callback",
+  "event_id": "EvQUSQG7V1",
+  "event_time": 1575305487,
+  "authed_users": [
+    "UA22B84GG"
+  ]
+}


### PR DESCRIPTION
This pr adds support for the `app_mention` event type as [documented here](https://api.slack.com/events/app_mention). The app mention event is useful for limiting calls to a bot service to only when the bot/app is explicitly mentioned. 

I've made the structure match the message event because, according to the docs, they are interchangeable:
> `app_mention` events are just like other message events sent over the Events API, but their type indicates `app_mention`.