### PR TITLE
Adds support for link_shared events

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ If you're not familiar with Java 8's `CompletableFuture` API, know that you can 
 
 ## Contributors
  - [@johnnyleitrim](https://github.com/johnnyleitrim) | [:computer:](https://github.com/HubSpot/slack-client/commits?author=johnnyleitrim)
+ - [@kecarroll](https://github.com/kecarroll) | [:computer:](https://github.com/HubSpot/slack-client/commits?author=kecarroll)
  - [@szabowexler](https://github.com/szabowexler) | [:computer:](https://github.com/HubSpot/slack-client/commits?author=szabowexler)
  - [@zklapow](https://github.com/zklapow) | [:computer:](https://github.com/HubSpot/slack-client/commits?author=zklapow)
  - [@wsorenson](https://github.com/wsorenson) | [:computer:](https://github.com/HubSpot/slack-client/commits?author=wsorenson)

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventType.java
@@ -8,6 +8,7 @@ import com.hubspot.slack.client.models.events.channel.SlackChannelCreatedEvent;
 import com.hubspot.slack.client.models.events.channel.SlackChannelDeletedEvent;
 import com.hubspot.slack.client.models.events.channel.SlackChannelRenameEvent;
 import com.hubspot.slack.client.models.events.channel.SlackChannelUnarchiveEvent;
+import com.hubspot.slack.client.models.events.links.SlackLinkSharedEvent;
 import com.hubspot.slack.client.models.events.user.SlackMemberJoinedChannelEvent;
 import com.hubspot.slack.client.models.events.user.SlackUserChangeEvent;
 
@@ -46,7 +47,7 @@ public enum SlackEventType {
   IM_CREATED,
   IM_HISTORY_CHANGED,
   IM_OPEN,
-  LINK_SHARED,
+  LINK_SHARED(SlackLinkSharedEvent.class),
   MEMBER_JOINED_CHANNEL(SlackMemberJoinedChannelEvent.class),
   MEMBER_LEFT_CHANNEL,
   MESSAGE(SlackEventMessage.class),

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/links/LinkIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/links/LinkIF.java
@@ -1,0 +1,13 @@
+package com.hubspot.slack.client.models.events.links;
+
+import org.immutables.value.Value.Immutable;
+
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+public interface LinkIF {
+  String getDomain();
+
+  String getUrl();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/links/SlackLinkSharedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/links/SlackLinkSharedEventIF.java
@@ -1,0 +1,37 @@
+package com.hubspot.slack.client.models.events.links;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.events.SlackEvent;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackLinkSharedEvent.class)
+public interface SlackLinkSharedEventIF extends SlackEvent {
+  @JsonProperty("channel")
+  String getChannelId();
+
+  @JsonProperty("user")
+  String getUserId();
+
+  String getMessageTs();
+
+  Optional<String> getThreadTs();
+
+  List<Link> getLinks();
+
+  //link_shared events do not have a ts, so we manually set it as null
+  @Override
+  default String getTs() {
+    return null;
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/events/json/EventDeserializerTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/events/json/EventDeserializerTest.java
@@ -14,6 +14,7 @@ import com.hubspot.slack.client.models.JsonLoader;
 import com.hubspot.slack.client.models.events.SlackEvent;
 import com.hubspot.slack.client.models.events.SlackEventType;
 import com.hubspot.slack.client.models.events.SlackEventWrapper;
+import com.hubspot.slack.client.models.events.links.SlackLinkSharedEvent;
 import com.hubspot.slack.client.models.events.user.SlackMemberJoinedChannelEvent;
 import com.hubspot.slack.client.models.events.user.SlackUserChangeEvent;
 
@@ -118,6 +119,21 @@ public class EventDeserializerTest {
     SlackUserChangeEvent event = fetchAndDeserializeSlackEvent("user_change.json").toDetailedEvent();
     assertThat(event.getType()).isEqualTo(SlackEventType.USER_CHANGE);
     assertThat(event.getUser().isDeleted().isPresent() && event.getUser().isDeleted().get());
+  }
+
+  @Test
+  public void itCanDeserLinkSharedEvent() throws IOException {
+    SlackLinkSharedEvent event = fetchAndDeserializeSlackEvent("link_shared.json").toDetailedEvent();
+    assertThat(event.getType()).isEqualTo(SlackEventType.LINK_SHARED);
+    assertThat(ObjectMapperUtils.mapper().readValue(ObjectMapperUtils.mapper().writeValueAsString(event), SlackLinkSharedEvent.class)).isEqualTo(event);
+  }
+
+  @Test
+  public void itCanDeserLinkSharedEventWithThreadTs() throws IOException {
+    SlackLinkSharedEvent event = fetchAndDeserializeSlackEvent("link_shared_with_thread_ts.json").toDetailedEvent();
+    assertThat(event.getType()).isEqualTo(SlackEventType.LINK_SHARED);
+    assertTrue(event.getThreadTs().isPresent());
+    assertThat(ObjectMapperUtils.mapper().readValue(ObjectMapperUtils.mapper().writeValueAsString(event), SlackLinkSharedEvent.class)).isEqualTo(event);
   }
 
   private SlackEvent fetchAndDeserializeSlackEvent(String jsonFileName) throws IOException {

--- a/slack-base/src/test/resources/link_shared.json
+++ b/slack-base/src/test/resources/link_shared.json
@@ -1,0 +1,31 @@
+{
+  "token": "redacted",
+  "team_id": "redacted",
+  "api_app_id": "redacted",
+  "event": {
+    "type": "link_shared",
+    "user": "redacted",
+    "channel": "redacted",
+    "message_ts": "123456789.9875",
+    "links": [
+      {
+        "domain": "example.com",
+        "url": "https://example.com/12345"
+      },
+      {
+        "domain": "example.com",
+        "url": "https://example.com/67890"
+      },
+      {
+        "domain": "another-example.com",
+        "url": "https://yet.another-example.com/v/abcde"
+      }
+    ]
+  },
+  "type": "event_callback",
+  "event_id": "EvDQSNTKPX",
+  "event_time": 1540822163,
+  "authed_users": [
+    "redacted"
+  ]
+}

--- a/slack-base/src/test/resources/link_shared_with_thread_ts.json
+++ b/slack-base/src/test/resources/link_shared_with_thread_ts.json
@@ -1,0 +1,32 @@
+{
+  "token": "redacted",
+  "team_id": "redacted",
+  "api_app_id": "redacted",
+  "event": {
+    "type": "link_shared",
+    "user": "redacted",
+    "channel": "redacted",
+    "message_ts": "123456789.9875",
+    "thread_ts": "123456621.1855",
+    "links": [
+      {
+        "domain": "example.com",
+        "url": "https://example.com/12345"
+      },
+      {
+        "domain": "example.com",
+        "url": "https://example.com/67890"
+      },
+      {
+        "domain": "another-example.com",
+        "url": "https://yet.another-example.com/v/abcde"
+      }
+    ]
+  },
+  "type": "event_callback",
+  "event_id": "EvDQSNTKPX",
+  "event_time": 1540822163,
+  "authed_users": [
+    "redacted"
+  ]
+}


### PR DESCRIPTION
Adds support for [link_shared](https://api.slack.com/events/link_shared) events from the Slack Events API. 

Slack sends this event over the Events API for Slack apps set up to track a specific URL domain