### PR TITLE
Temporarily ignore blocks on serde

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/LiteMessageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/LiteMessageIF.java
@@ -9,6 +9,7 @@ import org.immutables.value.Value.Immutable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -39,6 +40,9 @@ public interface LiteMessageIF {
 
   List<SlackFile> getFiles();
 
+  // Slack has some undocumented goodness (mentioned here: https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less)
+  // We're going to ignore blocks on messages for now until they update docs or we can verify all rich elements deserialize correctly
+  @JsonIgnore
   List<Block> getBlocks();
 
   @JsonProperty("ts")


### PR DESCRIPTION
Slack quietly (but effectively) broke their public API by adding some relatively undocumented fields. If you look at their [WYSIWYG](https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less) announcement, it lays out that they will be adding a `rich_text` field that has `rich_text_section` that can include other, even undocumented(!), elements.

Until we can figure this out, this change makes the block field on the lite message class optional so we won't fail to deserialize magical unknown fields.