### PR TITLE
Handle unknown block and block element types

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/LiteMessageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/LiteMessageIF.java
@@ -9,7 +9,6 @@ import org.immutables.value.Value.Immutable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -40,9 +39,6 @@ public interface LiteMessageIF {
 
   List<SlackFile> getFiles();
 
-  // Slack has some undocumented goodness (mentioned here: https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less)
-  // We're going to ignore blocks on messages for now until they update docs or we can verify all rich elements deserialize correctly
-  @JsonIgnore
   List<Block> getBlocks();
 
   @JsonProperty("ts")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/Block.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/Block.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = UnknownBlock.class)
 @JsonSubTypes({
     @JsonSubTypes.Type(value = Actions.class, name = Actions.TYPE),
     @JsonSubTypes.Type(value = Context.class, name = Context.TYPE),

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/UnknownBlock.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/UnknownBlock.java
@@ -1,0 +1,18 @@
+package com.hubspot.slack.client.models.blocks;
+
+import java.util.Optional;
+
+public class UnknownBlock implements Block {
+  protected UnknownBlock() {
+  }
+
+  @Override
+  public String getType() {
+    return "";
+  }
+
+  @Override
+  public Optional<String> getBlockId() {
+    return Optional.empty();
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/UnknownBlock.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/UnknownBlock.java
@@ -3,12 +3,14 @@ package com.hubspot.slack.client.models.blocks;
 import java.util.Optional;
 
 public class UnknownBlock implements Block {
+  public static final String TYPE = "unknown";
+
   protected UnknownBlock() {
   }
 
   @Override
   public String getType() {
-    return "";
+    return TYPE;
   }
 
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/BlockElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/BlockElement.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = UnknownBlockElement.class)
 @JsonSubTypes({
     @JsonSubTypes.Type(value = Button.class, name = Button.TYPE),
     @JsonSubTypes.Type(value = DatePicker.class, name = DatePicker.TYPE),

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UnknownBlockElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UnknownBlockElement.java
@@ -1,11 +1,13 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 public class UnknownBlockElement implements BlockElement {
+  public static final String TYPE = "unknown";
+
   protected UnknownBlockElement() {
   }
 
   @Override
   public String getType() {
-    return "";
+    return TYPE;
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UnknownBlockElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UnknownBlockElement.java
@@ -1,0 +1,11 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+public class UnknownBlockElement implements BlockElement {
+  protected UnknownBlockElement() {
+  }
+
+  @Override
+  public String getType() {
+    return "";
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/blocks/BlockSerializationTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/blocks/BlockSerializationTest.java
@@ -1,12 +1,27 @@
 package com.hubspot.slack.client.models.blocks;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 
+import org.junit.Test;
+
 import com.hubspot.slack.client.SerializationTestBase;
+import com.hubspot.slack.client.jackson.ObjectMapperUtils;
+import com.hubspot.slack.client.models.JsonLoader;
 
 public class BlockSerializationTest extends SerializationTestBase {
 
+  @Test
   public void testBlockSerialization() throws IOException {
     testSerialization("blocks.json", Block[].class);
+  }
+
+  @Test
+  public void testUnknownBlockSerialization() throws IOException {
+    String rawJson = JsonLoader.loadJsonFromFile("unknown_blocks.json");
+    Block[] blocks = ObjectMapperUtils.mapper().readValue(rawJson, Block[].class);
+    assertThat(blocks.length).isEqualTo(1);
+    assertThat(blocks[0]).isInstanceOf(UnknownBlock.class);
   }
 }

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/blocks/elements/BlockElementSerializationTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/blocks/elements/BlockElementSerializationTest.java
@@ -1,15 +1,27 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 
 import org.junit.Test;
 
 import com.hubspot.slack.client.SerializationTestBase;
+import com.hubspot.slack.client.jackson.ObjectMapperUtils;
+import com.hubspot.slack.client.models.JsonLoader;
+import com.hubspot.slack.client.models.blocks.Section;
 
 public class BlockElementSerializationTest extends SerializationTestBase {
 
   @Test
   public void testBlockSerialization() throws IOException {
     testSerialization("block_elements.json", BlockElement[].class);
+  }
+
+  @Test
+  public void testUnknownBlockSerialization() throws IOException {
+    String rawJson = JsonLoader.loadJsonFromFile("unknown_block_element.json");
+    Section section = ObjectMapperUtils.mapper().readValue(rawJson, Section.class);
+    assertThat(section.getAccessory().get()).isInstanceOf(UnknownBlockElement.class);
   }
 }

--- a/slack-base/src/test/resources/unknown_block_element.json
+++ b/slack-base/src/test/resources/unknown_block_element.json
@@ -1,0 +1,16 @@
+{
+  "type": "section",
+  "text": {
+    "type": "mrkdwn",
+    "text": "A section with an _unknown_ accessory type."
+  },
+  "accessory": {
+    "type": "rich_text_section",
+    "elements": [
+      {
+        "type": "text",
+        "text": "blah"
+      }
+    ]
+  }
+}

--- a/slack-base/src/test/resources/unknown_blocks.json
+++ b/slack-base/src/test/resources/unknown_blocks.json
@@ -1,0 +1,16 @@
+[
+  {
+    "type": "rich_text",
+    "elements": [
+      {
+        "type": "rich_text_section",
+        "elements": [
+          {
+            "type": "text",
+            "text": "blah"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Handle unknown block and block element types by having a default Unknown type for each.

On [this page](https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less), Slack have said:

> Expect to encounter other (even undocumented) elements.

Therefore, we will likely never know beforehand the entire list of blocks and block elements that may be returned, so this is our mechanism for handling unknown types.