### PR TITLE
Add is_private and is_member fields to channel/conversation

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/SlackChannelIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/SlackChannelIF.java
@@ -18,6 +18,8 @@ public interface SlackChannelIF {
   String getName();
   Optional<Boolean> getIsArchived();
   Optional<Boolean> getIsGeneral();
+  Optional<Boolean> getIsPrivate();
+  Optional<Boolean> getIsMember();
 
   @Derived
   @JsonIgnore

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/conversations/ConversationIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/conversations/ConversationIF.java
@@ -27,4 +27,8 @@ public interface ConversationIF {
   Optional<Boolean> isArchived();
   @JsonProperty("is_general")
   Optional<Boolean> isGeneral();
+  @JsonProperty("is_private")
+  Optional<Boolean> isPrivate();
+  @JsonProperty("is_member")
+  Optional<Boolean> isMember();
 }


### PR DESCRIPTION
Add support for the `is_private` and `is_member` fields on the channel/conversations response.