### PR TITLE
app_home_opened event support

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventType.java
@@ -3,6 +3,7 @@ package com.hubspot.slack.client.models.events;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.hubspot.slack.client.enums.EnumIndex;
+import com.hubspot.slack.client.models.events.bot.SlackAppHomeOpenedEvent;
 import com.hubspot.slack.client.models.events.channel.SlackChannelArchiveEvent;
 import com.hubspot.slack.client.models.events.channel.SlackChannelCreatedEvent;
 import com.hubspot.slack.client.models.events.channel.SlackChannelDeletedEvent;
@@ -14,6 +15,7 @@ import com.hubspot.slack.client.models.events.user.SlackUserChangeEvent;
 
 public enum SlackEventType {
 
+  APP_HOME_OPENED(SlackAppHomeOpenedEvent.class),
   APP_MENTION(SlackEventMessage.class),
   APP_UNINSTALLED,
   CHANNEL_ARCHIVE(SlackChannelArchiveEvent.class),

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.methods.interceptor.HasUser;
 import com.hubspot.slack.client.models.events.SlackEvent;
 import com.hubspot.slack.client.models.response.views.HomeTabViewResponseIF;
 import org.immutables.value.Value;
@@ -15,7 +16,7 @@ import java.util.Optional;
 @HubSpotStyle
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackAppHomeOpenedEvent.class)
-public interface SlackAppHomeOpenedEventIF extends SlackEvent {
+public interface SlackAppHomeOpenedEventIF extends SlackEvent, HasUser {
     String getTab();
 
     Optional<HomeTabViewResponseIF> getView();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
@@ -9,6 +9,8 @@ import com.hubspot.slack.client.models.events.SlackEvent;
 import com.hubspot.slack.client.models.response.views.HomeTabViewResponseIF;
 import org.immutables.value.Value;
 
+import java.util.Optional;
+
 @Value.Immutable
 @HubSpotStyle
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
@@ -16,7 +18,7 @@ import org.immutables.value.Value;
 public interface SlackAppHomeOpenedEventIF extends SlackEvent {
     String getTab();
 
-    HomeTabViewResponseIF getView();
+    Optional<HomeTabViewResponseIF> getView();
 
     @JsonProperty("user")
     String getUserId();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
@@ -1,0 +1,33 @@
+package com.hubspot.slack.client.models.events.bot;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.events.SlackEvent;
+import com.hubspot.slack.client.models.response.views.HomeTabViewResponseIF;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackAppHomeOpenedEvent.class)
+public interface SlackAppHomeOpenedEventIF extends SlackEvent {
+    String getTab();
+
+    HomeTabViewResponseIF getView();
+
+    @JsonProperty("user")
+    String getUserId();
+
+    @JsonProperty("channel")
+    String getChannelId();
+
+    //Home opened events do not have a ts, so we manually set it as null
+    @Override
+    default String getTs() {
+        return null;
+    }
+
+}


### PR DESCRIPTION
This little patch moves the `app_home_opened` incoming event from the realm of being unknown (`SlackEventType.UNKNOWN`) and thus turned into a simple `SlackEventSkeleton` object to something more useful: a full blown `SlackAppHomeOpenedEvent` that contains the current view payload.

PS: Not sure if the package name "bot" or "views" would have been better.