### PR TITLE
app_home_opened event support

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventType.java
@@ -3,6 +3,7 @@ package com.hubspot.slack.client.models.events;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.hubspot.slack.client.enums.EnumIndex;
+import com.hubspot.slack.client.models.events.bot.SlackAppHomeOpenedEvent;
 import com.hubspot.slack.client.models.events.channel.SlackChannelArchiveEvent;
 import com.hubspot.slack.client.models.events.channel.SlackChannelCreatedEvent;
 import com.hubspot.slack.client.models.events.channel.SlackChannelDeletedEvent;
@@ -14,6 +15,7 @@ import com.hubspot.slack.client.models.events.user.SlackUserChangeEvent;
 
 public enum SlackEventType {
 
+  APP_HOME_OPENED(SlackAppHomeOpenedEvent.class),
   APP_MENTION(SlackEventMessage.class),
   APP_UNINSTALLED,
   CHANNEL_ARCHIVE(SlackChannelArchiveEvent.class),

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.methods.interceptor.HasUser;
 import com.hubspot.slack.client.models.events.SlackEvent;
 import com.hubspot.slack.client.models.response.views.HomeTabViewResponseIF;
 import org.immutables.value.Value;
@@ -15,7 +16,7 @@ import java.util.Optional;
 @HubSpotStyle
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackAppHomeOpenedEvent.class)
-public interface SlackAppHomeOpenedEventIF extends SlackEvent {
+public interface SlackAppHomeOpenedEventIF extends SlackEvent, HasUser {
     String getTab();
 
     Optional<HomeTabViewResponseIF> getView();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasUser;
 import com.hubspot.slack.client.models.events.SlackEvent;
-import com.hubspot.slack.client.models.response.views.HomeTabViewResponseIF;
+import com.hubspot.slack.client.models.response.views.HomeTabViewResponse;
 import org.immutables.value.Value;
 
 import java.util.Optional;
@@ -19,7 +19,7 @@ import java.util.Optional;
 public interface SlackAppHomeOpenedEventIF extends SlackEvent, HasUser {
     String getTab();
 
-    Optional<HomeTabViewResponseIF> getView();
+    Optional<HomeTabViewResponse> getView();
 
     @JsonProperty("user")
     String getUserId();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
@@ -9,6 +9,8 @@ import com.hubspot.slack.client.models.events.SlackEvent;
 import com.hubspot.slack.client.models.response.views.HomeTabViewResponseIF;
 import org.immutables.value.Value;
 
+import java.util.Optional;
+
 @Value.Immutable
 @HubSpotStyle
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
@@ -16,7 +18,7 @@ import org.immutables.value.Value;
 public interface SlackAppHomeOpenedEventIF extends SlackEvent {
     String getTab();
 
-    HomeTabViewResponseIF getView();
+    Optional<HomeTabViewResponseIF> getView();
 
     @JsonProperty("user")
     String getUserId();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
@@ -1,0 +1,33 @@
+package com.hubspot.slack.client.models.events.bot;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.events.SlackEvent;
+import com.hubspot.slack.client.models.response.views.HomeTabViewResponseIF;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackAppHomeOpenedEvent.class)
+public interface SlackAppHomeOpenedEventIF extends SlackEvent {
+    String getTab();
+
+    HomeTabViewResponseIF getView();
+
+    @JsonProperty("user")
+    String getUserId();
+
+    @JsonProperty("channel")
+    String getChannelId();
+
+    //Home opened events do not have a ts, so we manually set it as null
+    @Override
+    default String getTs() {
+        return null;
+    }
+
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/events/json/EventDeserializerTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/events/json/EventDeserializerTest.java
@@ -20,6 +20,12 @@ import com.hubspot.slack.client.models.events.user.SlackUserChangeEvent;
 
 public class EventDeserializerTest {
   @Test
+  public void itCanDeserAppHomeOpened() throws IOException {
+    SlackEvent event = fetchAndDeserializeSlackEvent("app_home_opened.json");
+    assertThat(event.getType()).isEqualTo(SlackEventType.APP_HOME_OPENED);
+  }
+
+  @Test
   public void itCanDeserAppMentionMessage() throws IOException {
     SlackEvent event = fetchAndDeserializeSlackEvent("app_mention_message.json");
     assertThat(event.getType()).isEqualTo(SlackEventType.APP_MENTION);

--- a/slack-base/src/test/resources/app_home_opened.json
+++ b/slack-base/src/test/resources/app_home_opened.json
@@ -1,0 +1,58 @@
+{
+  "token": "redacted",
+  "team_id": "redacted",
+  "api_app_id": "redacted",
+  "event": {
+    "type": "app_home_opened",
+    "user": "U061F7AUR",
+    "channel": "D0LAN2Q65",
+    "event_ts": "1515449522000016",
+    "tab": "home",
+    "view": {
+      "id": "VPASKP233",
+      "team_id": "T21312902",
+      "type": "home",
+      "blocks": [
+        {
+          "type": "rich_text",
+          "block_id": "GxKF",
+          "elements": [
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "user",
+                  "user_id": "UA22B84GG"
+                },
+                {
+                  "type": "text",
+                  "text": " help"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "private_metadata": "",
+      "callback_id": "",
+      "state": {
+        "values": {}
+      },
+      "hash":"1231232323.12321312",
+      "clear_on_close": false,
+      "notify_on_close": false,
+      "root_view_id": "VPASKP233",
+      "app_id": "A21SDS90",
+      "external_id": "",
+      "app_installed_team_id": "T21312902",
+      "bot_id": "BSDKSAO2"
+    }
+  }
+,
+  "type": "event_callback",
+  "event_id": "EvQUSQG7V1",
+  "event_time": 1575305487,
+  "authed_users": [
+    "UA22B84GG"
+  ]
+}


### PR DESCRIPTION
This little patch moves the app_home_opened incoming event from the realm of being unknown (SlackEventType.UNKNOWN) and thus turned into a simple SlackEventSkeleton object to something more useful: a full blown SlackAppHomeOpenedEvent that contains the current view payload.

PS: Not sure if the package name "bot" or "views" would have been better.

