### PR TITLE
#130: Add a custom deserialiser for OptionOrOptionGroup, so that it is deserialised correctly.

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalMultiSelectMenuIF.java
@@ -8,8 +8,10 @@ import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.json.OptionOrOptionGroupDeserializer;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
 import com.hubspot.slack.client.models.blocks.objects.OptionOrOptionGroup;
 import com.hubspot.slack.client.models.blocks.objects.Text;
@@ -34,6 +36,7 @@ public interface ExternalMultiSelectMenuIF extends BlockElement {
 
   Optional<Integer> getMinQueryLength();
 
+  @JsonDeserialize(contentUsing = OptionOrOptionGroupDeserializer.class)
   List<OptionOrOptionGroup> getInitialOptions();
 
   @JsonProperty("confirm")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticMultiSelectMenuIF.java
@@ -8,8 +8,10 @@ import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.json.OptionOrOptionGroupDeserializer;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
 import com.hubspot.slack.client.models.blocks.objects.Option;
 import com.hubspot.slack.client.models.blocks.objects.OptionGroup;
@@ -39,6 +41,7 @@ public interface StaticMultiSelectMenuIF extends BlockElement {
 
   List<OptionGroup> getOptionGroups();
 
+  @JsonDeserialize(contentUsing = OptionOrOptionGroupDeserializer.class)
   List<OptionOrOptionGroup> getInitialOptions();
 
   @JsonProperty("confirm")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticSelectMenuIF.java
@@ -8,8 +8,10 @@ import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.json.OptionOrOptionGroupDeserializer;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
 import com.hubspot.slack.client.models.blocks.objects.Option;
 import com.hubspot.slack.client.models.blocks.objects.OptionGroup;
@@ -39,6 +41,7 @@ public interface StaticSelectMenuIF extends BlockElement {
 
   List<OptionGroup> getOptionGroups();
 
+  @JsonDeserialize(contentUsing = OptionOrOptionGroupDeserializer.class)
   Optional<OptionOrOptionGroup> getInitialOption();
 
   @JsonProperty("confirm")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/json/OptionOrOptionGroupDeserializer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/json/OptionOrOptionGroupDeserializer.java
@@ -1,0 +1,32 @@
+package com.hubspot.slack.client.models.blocks.json;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.hubspot.slack.client.models.blocks.objects.Option;
+import com.hubspot.slack.client.models.blocks.objects.OptionGroup;
+import com.hubspot.slack.client.models.blocks.objects.OptionOrOptionGroup;
+
+public class OptionOrOptionGroupDeserializer extends StdDeserializer<OptionOrOptionGroup> {
+  private static final String OPTIONS_FIELD = "options";
+
+  protected OptionOrOptionGroupDeserializer() {
+    super(OptionOrOptionGroup.class);
+  }
+
+  @Override
+  public OptionOrOptionGroup deserialize(JsonParser p, DeserializationContext context) throws IOException {
+    ObjectCodec codec = p.getCodec();
+    JsonNode node = codec.readTree(p);
+
+    if (node.has(OPTIONS_FIELD)) {
+      return codec.treeToValue(node, OptionGroup.class);
+    }
+
+    return codec.treeToValue(node, Option.class);
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/ConfirmationDialogIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/ConfirmationDialogIF.java
@@ -11,7 +11,7 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface ConfirmationDialogIF extends OptionOrOptionGroup {
+public interface ConfirmationDialogIF extends CompositionObject {
   @Value.Parameter
   Text getTitle();
 

--- a/slack-base/src/test/resources/block_elements.json
+++ b/slack-base/src/test/resources/block_elements.json
@@ -48,6 +48,21 @@
       "type": "plain_text",
       "text": "Select items"
     },
+    "initial_options": [{
+      "label": {
+        "type": "plain_text",
+        "text": "This is a label"
+      },
+      "options": [
+        {
+          "text": {
+            "type": "plain_text",
+            "text": "*this is plain_text text*"
+          },
+          "value": "value-0"
+        }
+      ]
+    }],
     "options": [
       {
         "text": {
@@ -210,7 +225,14 @@
         },
         "value": "value-2"
       }
-    ]
+    ],
+    "initial_option": {
+      "text": {
+        "type": "plain_text",
+        "text": "*this is plain_text text*"
+      },
+      "value": "value-0"
+    }
   },
   {
     "action_id": "text1234",


### PR DESCRIPTION
Similar to `ImageBlockOrText`, add a custom deserialiser to handle `OptionOrOptionGroup`

Fixes #130 