### PR TITLE
supported for selected_option as an alternative to the value field

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/json/BlockElementActionDeserializer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/json/BlockElementActionDeserializer.java
@@ -13,6 +13,7 @@ import com.hubspot.slack.client.models.interaction.BlockElementAction;
 
 public class BlockElementActionDeserializer extends StdDeserializer<BlockElementAction> {
   private static final String BLOCK_ID_FIELD = "block_id";
+  private static final String SELECTED_OPTION_FIELD = "selected_option";
   private static final String VALUE_FIELD = "value";
   private static final String ACTION_TS_FIELD = "action_ts";
 
@@ -28,7 +29,7 @@ public class BlockElementActionDeserializer extends StdDeserializer<BlockElement
     builder.setBlockId(node.get(BLOCK_ID_FIELD).asText());
 
     // select menu elements don't send a value field, they send a `selected_option` object that has a value field
-    if (node.has("selected_option")) {
+    if (node.has(SELECTED_OPTION_FIELD)) {
       builder.setSelectedValue(readOptionalString(node.get("selected_option"), VALUE_FIELD));
     } else {
       builder.setSelectedValue(readOptionalString(node, VALUE_FIELD));

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/json/BlockElementActionDeserializer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/json/BlockElementActionDeserializer.java
@@ -26,7 +26,14 @@ public class BlockElementActionDeserializer extends StdDeserializer<BlockElement
     ObjectCodec codec = p.getCodec();
     JsonNode node = codec.readTree(p);
     builder.setBlockId(node.get(BLOCK_ID_FIELD).asText());
-    builder.setSelectedValue(readOptionalString(node, VALUE_FIELD));
+
+    // select menu elements don't send a value field, they send a `selected_option` object that has a value field
+    if (node.has("selected_option")) {
+      builder.setSelectedValue(readOptionalString(node.get("selected_option"), VALUE_FIELD));
+    } else {
+      builder.setSelectedValue(readOptionalString(node, VALUE_FIELD));
+    }
+
     builder.setActionTs(readOptionalString(node, ACTION_TS_FIELD));
     BlockElement element = codec.treeToValue(node, BlockElement.class);
     builder.setElement(element);


### PR DESCRIPTION
Even though the Slack API docs say that when an user select's a menu, the interaction's value should arrive in the "value" field, I believe the docs are incorrect and reality is different.

Specifically, what I am seeing in the real world is that select menus will have their value arrive instead as a "selected_option" field. Thus, this deserializer will inspect for this field and pull the value from there if present.