### PR TITLE
common interface for BlockElements that also have an action_id

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ButtonIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ButtonIF.java
@@ -15,7 +15,7 @@ import com.hubspot.slack.client.models.blocks.objects.Text;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface ButtonIF extends BlockElement {
+public interface ButtonIF extends BlockElement, HasActionId {
   String TYPE = "button";
 
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelSelectMenuIF.java
@@ -15,7 +15,7 @@ import com.hubspot.slack.client.models.blocks.objects.Text;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface ChannelSelectMenuIF extends BlockElement {
+public interface ChannelSelectMenuIF extends BlockElement, HasActionId {
   String TYPE = "channels_select";
 
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelsMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelsMultiSelectMenuIF.java
@@ -16,7 +16,7 @@ import com.hubspot.slack.client.models.blocks.objects.Text;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface ChannelsMultiSelectMenuIF extends BlockElement {
+public interface ChannelsMultiSelectMenuIF extends BlockElement, HasActionId {
   String TYPE = "multi_conversations_select";
 
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationSelectMenuIF.java
@@ -15,7 +15,7 @@ import com.hubspot.slack.client.models.blocks.objects.Text;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface ConversationSelectMenuIF extends BlockElement {
+public interface ConversationSelectMenuIF extends BlockElement, HasActionId {
   String TYPE = "conversations_select";
 
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationsMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationsMultiSelectMenuIF.java
@@ -16,7 +16,7 @@ import com.hubspot.slack.client.models.blocks.objects.Text;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface ConversationsMultiSelectMenuIF extends BlockElement {
+public interface ConversationsMultiSelectMenuIF extends BlockElement, HasActionId {
   String TYPE = "multi_channels_select";
 
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/DatePickerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/DatePickerIF.java
@@ -17,7 +17,7 @@ import com.hubspot.slack.client.models.blocks.objects.Text;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface DatePickerIF extends BlockElement {
+public interface DatePickerIF extends BlockElement, HasActionId {
   String TYPE = "datepicker";
 
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalMultiSelectMenuIF.java
@@ -17,7 +17,7 @@ import com.hubspot.slack.client.models.blocks.objects.Text;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface ExternalMultiSelectMenuIF extends BlockElement {
+public interface ExternalMultiSelectMenuIF extends BlockElement, HasActionId {
   String TYPE = "multi_external_select";
 
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalSelectMenuIF.java
@@ -16,7 +16,7 @@ import com.hubspot.slack.client.models.blocks.objects.Text;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface ExternalSelectMenuIF extends BlockElement {
+public interface ExternalSelectMenuIF extends BlockElement, HasActionId {
   String TYPE = "external_select";
 
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/HasActionId.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/HasActionId.java
@@ -1,0 +1,5 @@
+package com.hubspot.slack.client.models.blocks.elements;
+
+public interface HasActionId {
+    String getActionId();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/OverflowMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/OverflowMenuIF.java
@@ -16,7 +16,7 @@ import com.hubspot.slack.client.models.blocks.objects.Option;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface OverflowMenuIF extends BlockElement {
+public interface OverflowMenuIF extends BlockElement, HasActionId {
   String TYPE = "overflow";
 
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/PlainTextInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/PlainTextInputIF.java
@@ -14,7 +14,7 @@ import com.hubspot.slack.client.models.blocks.objects.Text;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface PlainTextInputIF extends BlockElement {
+public interface PlainTextInputIF extends BlockElement, HasActionId {
   String TYPE = "plain_text_input";
 
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/RadioButtonGroupIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/RadioButtonGroupIF.java
@@ -16,7 +16,7 @@ import com.hubspot.slack.client.models.blocks.objects.Option;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface RadioButtonGroupIF extends BlockElement {
+public interface RadioButtonGroupIF extends BlockElement, HasActionId {
   String TYPE = "radio_buttons";
 
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticMultiSelectMenuIF.java
@@ -19,7 +19,7 @@ import com.hubspot.slack.client.models.blocks.objects.Text;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface StaticMultiSelectMenuIF extends BlockElement {
+public interface StaticMultiSelectMenuIF extends BlockElement, HasActionId {
   String TYPE = "multi_static_select";
 
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticSelectMenuIF.java
@@ -19,7 +19,7 @@ import com.hubspot.slack.client.models.blocks.objects.Text;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface StaticSelectMenuIF extends BlockElement {
+public interface StaticSelectMenuIF extends BlockElement, HasActionId {
   String TYPE = "static_select";
 
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UserSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UserSelectMenuIF.java
@@ -15,7 +15,7 @@ import com.hubspot.slack.client.models.blocks.objects.Text;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface UserSelectMenuIF extends BlockElement {
+public interface UserSelectMenuIF extends BlockElement, HasActionId {
   String TYPE = "users_select";
 
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UsersMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UsersMultiSelectMenuIF.java
@@ -16,7 +16,7 @@ import com.hubspot.slack.client.models.blocks.objects.Text;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface UsersMultiSelectMenuIF extends BlockElement {
+public interface UsersMultiSelectMenuIF extends BlockElement, HasActionId {
   String TYPE = "multi_users_select";
 
   @Override


### PR DESCRIPTION
Even though the Slack API docs say that when an user select's a menu, the interaction's value should arrive in the "value" field, I believe the docs are incorrect and reality is different.

Specifically, what I am seeing in the real world is that select menus will have their value arrive instead as a "selected_option" field. Thus, this deserializer will inspect for this field and pull the value from there if present.