### PR TITLE
removes logging for deprecated field that has since been removed

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/LiteMessageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/LiteMessageIF.java
@@ -1,13 +1,9 @@
 package com.hubspot.slack.client.models;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
@@ -20,8 +16,6 @@ import com.hubspot.slack.client.models.files.SlackFile;
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 public interface LiteMessageIF {
-
-  Logger LOG = LoggerFactory.getLogger(LiteMessage.class);
 
   String getType();
 
@@ -56,16 +50,4 @@ public interface LiteMessageIF {
 
   @JsonProperty("latest_reply")
   Optional<String> getLatestReplyTimestamp();
-
-  /**
-   * @deprecated use {@link #getReplyUserIds()} or {@link #getLatestReplyTimestamp()}
-   * These can be used to find the user ids and the last reply timestamp.
-   * Used to return a list of `ReplySkeleton`
-   */
-  @Deprecated
-  @Default
-  default List<ReplySkeleton> getReplies() {
-    LOG.error("Method getReplies() is now deprecated. Slack will stop supporting completely on Oct 18th 2019");
-    return Collections.emptyList();
-  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/util/AbstractSlackReplyMessage.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/util/AbstractSlackReplyMessage.java
@@ -1,13 +1,10 @@
 package com.hubspot.slack.client.models.events.util;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
@@ -20,8 +17,6 @@ import com.hubspot.slack.client.models.events.SlackEventMessageBase;
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 public abstract class AbstractSlackReplyMessage extends SlackEventMessageBase implements HasUser {
-
-  Logger LOG = LoggerFactory.getLogger(SlackReplyMessage.class);
 
   public abstract String getThreadTs();
 
@@ -45,16 +40,4 @@ public abstract class AbstractSlackReplyMessage extends SlackEventMessageBase im
 
   @JsonProperty("latest_reply")
   public abstract Optional<String> getLatestReplyTimestamp();
-
-  /**
-   * @deprecated use {@link #getReplyUserIds()} or {@link #getLatestReplyTimestamp()}
-   * These can be used to find the user ids and the last reply timestamp.
-   * Used to return a list of `Reply`
-   */
-  @Deprecated
-  @Default
-  public List<Reply> getReplies() {
-    LOG.error("Method getReplies() is now deprecated. Slack will stop supporting completely on Oct 18th 2019");
-    return Collections.emptyList();
-  }
 }

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/response/conversations/ConversationsRepliesResponseTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/response/conversations/ConversationsRepliesResponseTest.java
@@ -22,7 +22,6 @@ public class ConversationsRepliesResponseTest {
     assertThat(response.getMessages().get(0).getReplyUserIds()).isEmpty();
     assertThat(response.getMessages().get(0).getReplyUsersCount()).isEmpty();
     assertThat(response.getMessages().get(0).getLatestReplyTimestamp()).isEmpty();
-    assertThat(response.getMessages().get(0).getReplies()).isNotEmpty();
   }
 
   @Test
@@ -34,7 +33,6 @@ public class ConversationsRepliesResponseTest {
     assertThat(response.getMessages().get(0).getReplyUserIds().get()).isEqualTo(Arrays.asList("U061F7AUR", "U061F7AUR", "U061F7AUR"));
     assertThat(response.getMessages().get(0).getReplyUsersCount().get()).isEqualTo(3);
     assertThat(response.getMessages().get(0).getLatestReplyTimestamp().get()).isEqualTo("1483125339.020269");
-    assertThat(response.getMessages().get(0).getReplies()).isNotEmpty();
   }
 
   @Test
@@ -46,7 +44,6 @@ public class ConversationsRepliesResponseTest {
     assertThat(response.getMessages().get(0).getReplyUserIds().get()).isEqualTo(Arrays.asList("U061F7AUR", "U061F7AUR", "U061F7AUR"));
     assertThat(response.getMessages().get(0).getReplyUsersCount().get()).isEqualTo(3);
     assertThat(response.getMessages().get(0).getLatestReplyTimestamp().get()).isEqualTo("1483125339.020269");
-    assertThat(response.getMessages().get(0).getReplies()).isEmpty();
   }
 
   private ConversationsRepliesResponse fetchAndDeserializeModel(String jsonFileName) throws IOException {


### PR DESCRIPTION
This removes the warnings about getReplies() being deprecated. I was finding that it was firing even thought I wasn't calling it, I believe because Jackson serialization was tickling the method. Rather than try to solve that issue, I realized that because the functionality has since been removed (October 2019), it probably makes sense to just delete it. 

If you agree, here is the PR.

If not, I'd like to figure out a way to get the warnings to stop :)