### PR TITLE
Changed object mapper to remove nulls from Json

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/jackson/ObjectMapperUtils.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/jackson/ObjectMapperUtils.java
@@ -3,6 +3,7 @@ package com.hubspot.slack.client.jackson;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -28,6 +29,7 @@ public final class ObjectMapperUtils {
     mapper.configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, true);
     mapper.configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, true);
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.setSerializationInclusion(Include.NON_NULL);
 
     return mapper;
   }


### PR DESCRIPTION
With slacks recent api changes. Any `chats.postMessage` request sending the `as_user` field, even if null, will get rejected. Confirmed with Ben Becker. 
* Removing nulls from the mapper is the quickest way of removing the null field without impacting anyone currently using the `as_user` functionality while unblocking  anyone not.