### PR TITLE
turns out the tab field appears to be optional in the real world :(

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasUser;
 import com.hubspot.slack.client.models.events.SlackEvent;
-import com.hubspot.slack.client.models.response.views.HomeTabViewResponse;
+import com.hubspot.slack.client.models.response.views.HomeTabViewResponseIF;
 import org.immutables.value.Value;
 
 import java.util.Optional;
@@ -17,9 +17,9 @@ import java.util.Optional;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackAppHomeOpenedEvent.class)
 public interface SlackAppHomeOpenedEventIF extends SlackEvent, HasUser {
-    String getTab();
+    Optional<String> getTab();
 
-    Optional<HomeTabViewResponse> getView();
+    Optional<HomeTabViewResponseIF> getView();
 
     @JsonProperty("user")
     String getUserId();


### PR DESCRIPTION
Got this error in our logs today. After re-reading the docs, it looks like they don't clear say whether it should always be sent or not, but given that the real world seems to push me events without a tab field, I think you should consider this change:

https://api.slack.com/events/app_home_opened