### PR TITLE
Allow explicit setting of as_user for legacy, but don't include if unset for new apps

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatPostEphemeralMessageParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatPostEphemeralMessageParamsIF.java
@@ -21,11 +21,8 @@ public interface ChatPostEphemeralMessageParamsIF extends MessageParams {
   @JsonProperty("user")
   String getUserToSendTo();
 
-  @Default
   @JsonProperty("as_user")
-  default boolean getSendAsUser() {
-    return false;
-  }
+  Optional<Boolean> getSendAsUser();
 
   @JsonProperty("thread_ts")
   Optional<String> getThreadTs();


### PR DESCRIPTION
Fixes #147. Slack changed their API in a way that works for legacy and fails for new apps. Thanks Slack. I'll need to test this to verify it doesn't immediately break usages, but once I've done that it should resolve this class of issue.