### PR TITLE
Don't serialize an absent value on as_user API option

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractChatMessageParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractChatMessageParams.java
@@ -2,6 +2,7 @@ package com.hubspot.slack.client.methods.params.chat;
 
 import java.util.Optional;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.immutables.value.Value.Check;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -17,6 +18,7 @@ public abstract class AbstractChatMessageParams implements MessageParams {
   public abstract Optional<String> getText();
   public abstract Optional<String> getThreadTs();
   public abstract Optional<String> getUsername();
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   public abstract Optional<Boolean> getAsUser();
   public abstract Optional<String> getIconEmoji();
   public abstract Optional<String> getIconUrl();


### PR DESCRIPTION
Slack has updated their API for V2 apps, and the as_user option will be rejected by V2 apps trying to use it. We can simply not serialize this field if it is not set, since it is optional.

To see more about Authorship https://api.slack.com/methods/chat.postMessage#authorship