### PR TITLE
Fix purpose and topic response models

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/conversations/ConversationSetPurposeResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/conversations/ConversationSetPurposeResponseIF.java
@@ -8,5 +8,4 @@ import com.hubspot.slack.client.models.response.SlackResponse;
 @Immutable
 @HubSpotStyle
 public interface ConversationSetPurposeResponseIF extends SlackResponse {
-  String getPurpose();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/conversations/ConversationSetTopicResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/conversations/ConversationSetTopicResponseIF.java
@@ -8,5 +8,4 @@ import com.hubspot.slack.client.models.response.SlackResponse;
 @Immutable
 @HubSpotStyle
 public interface ConversationSetTopicResponseIF extends SlackResponse {
-  String getTopic();
 }


### PR DESCRIPTION
As it turns out, Slack documentation is outdated and these APIs return another response format so we fail to parse JSON response to java model. I removed `topic` and `description` to be able to parse the response successfully.

- https://api.slack.com/methods/conversations.setTopic
- https://api.slack.com/methods/conversations.setPurpose

Response format specified in docs:
```
{
    "ok": true,
    "purpose": "I didn't set this purpose on purpose!"
}
```

Actual response format:
```
{
    "ok": true,
    "channel": {
        "id": "XXXXXX",
        "name": "xxx",
        "is_channel": true,
        "is_group": false,
        "is_im": false,
        "created": 1586792508,
        "is_archived": false,
        "is_general": false,
        "unlinked": 0,
        "name_normalized": "xxxx",
        "is_shared": false,
        "parent_conversation": null,
        "creator": "XXXXXX",
        "is_ext_shared": false,
        "is_org_shared": false,
        "shared_team_ids": [
            "XXXXXX"
        ],
        "pending_shared": [],
        "pending_connected_team_ids": [],
        "is_pending_ext_shared": false,
        "is_member": true,
        "is_private": false,
        "is_mpim": false,
        "last_read": "1586802670.001900",
        "topic": {
            "value": "something",
            "creator": "XXXXX",
            "last_set": 1586803927
        },
        "purpose": {
            "value": "something",
            "creator": "XXXX",
            "last_set": 1586803925
        },
        "previous_names": [
            "demo"
        ]
    }
}
```