### PR TITLE
Add enum mapping for view_submission interactive callback

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/InteractiveCallbackType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/InteractiveCallbackType.java
@@ -9,6 +9,7 @@ public enum InteractiveCallbackType {
   DIALOG_SUBMISSION,
   MESSAGE_ACTION,
   BLOCK_ACTIONS,
+  VIEW_SUBMISSION,
   UNKNOWN
   ;
 

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/interaction/SlackInteractiveCallbackTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/interaction/SlackInteractiveCallbackTest.java
@@ -1,0 +1,31 @@
+package com.hubspot.slack.client.models.interaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+
+public class SlackInteractiveCallbackTest {
+
+  @Test
+  public void checkAllInteractiveCallBackTypesAreMapped() {
+    JsonSubTypes jsonSubTypes = SlackInteractiveCallback.class.getAnnotation(JsonSubTypes.class);
+
+    Set<String> types = Arrays
+        .stream(jsonSubTypes.value())
+        .map(JsonSubTypes.Type::name)
+        .collect(Collectors.toSet());
+
+
+    for (String type : types) {
+      assertThat(InteractiveCallbackType.get(type))
+          .describedAs("Could not find enum mapping for %s", type)
+          .isNotEqualTo(InteractiveCallbackType.UNKNOWN);
+    }
+  }
+}


### PR DESCRIPTION
@szabowexler @johnnyleitrim 

Adds a proper mapping for `VIEW_SUBMISSION`. The object was being properly parsed, but the enum didn't exist. This PR adds the enum in and adds a tests that should automatically ensure that the json subtypes always maps the relevant enum type in the future.