### PR TITLE
Add model for Slack member_left_channel event

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventType.java
@@ -13,6 +13,7 @@ import com.hubspot.slack.client.models.events.channel.SlackChannelRenameEvent;
 import com.hubspot.slack.client.models.events.channel.SlackChannelUnarchiveEvent;
 import com.hubspot.slack.client.models.events.links.SlackLinkSharedEvent;
 import com.hubspot.slack.client.models.events.user.SlackMemberJoinedChannelEvent;
+import com.hubspot.slack.client.models.events.user.SlackMemberLeftChannelEvent;
 import com.hubspot.slack.client.models.events.user.SlackUserChangeEvent;
 
 public enum SlackEventType {
@@ -53,7 +54,7 @@ public enum SlackEventType {
   IM_OPEN,
   LINK_SHARED(SlackLinkSharedEvent.class),
   MEMBER_JOINED_CHANNEL(SlackMemberJoinedChannelEvent.class),
-  MEMBER_LEFT_CHANNEL,
+  MEMBER_LEFT_CHANNEL(SlackMemberLeftChannelEvent.class),
   MESSAGE(SlackEventMessage.class),
   PIN_ADDED,
   PIN_REMOVED,

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/user/SlackMemberLeftChannelEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/user/SlackMemberLeftChannelEventIF.java
@@ -1,0 +1,34 @@
+package com.hubspot.slack.client.models.events.user;
+
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.ChannelType;
+import com.hubspot.slack.client.models.events.SlackEvent;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackMemberLeftChannelEvent.class)
+public interface SlackMemberLeftChannelEventIF extends SlackEvent {
+
+  @JsonProperty("user")
+  String getUserId();
+
+  @JsonProperty("channel")
+  String getChannelId();
+
+  ChannelType getChannelType();
+
+  String getTeam();
+
+  //Member joined events do not have a ts, so we manually set it as null
+  @Override
+  default String getTs() {
+    return null;
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/events/json/EventDeserializerTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/events/json/EventDeserializerTest.java
@@ -130,7 +130,7 @@ public class EventDeserializerTest {
 
   @Test
   public void itCanDeserMemberLeftPrivateChannelEvent() throws IOException {
-    SlackMemberLeftChannelEvent event = fetchAndDeserializeSlackEvent("member_left_public_channel.json").toDetailedEvent();
+    SlackMemberLeftChannelEvent event = fetchAndDeserializeSlackEvent("member_left_private_channel.json").toDetailedEvent();
     assertThat(event.getType()).isEqualTo(SlackEventType.MEMBER_LEFT_CHANNEL);
     assertThat(ObjectMapperUtils.mapper().readValue(ObjectMapperUtils.mapper().writeValueAsString(event), SlackMemberLeftChannelEvent.class)).isEqualTo(event);
   }

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/events/json/EventDeserializerTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/events/json/EventDeserializerTest.java
@@ -16,6 +16,7 @@ import com.hubspot.slack.client.models.events.SlackEventType;
 import com.hubspot.slack.client.models.events.SlackEventWrapper;
 import com.hubspot.slack.client.models.events.links.SlackLinkSharedEvent;
 import com.hubspot.slack.client.models.events.user.SlackMemberJoinedChannelEvent;
+import com.hubspot.slack.client.models.events.user.SlackMemberLeftChannelEvent;
 import com.hubspot.slack.client.models.events.user.SlackUserChangeEvent;
 
 public class EventDeserializerTest {
@@ -118,6 +119,20 @@ public class EventDeserializerTest {
     assertThat(event.getType()).isEqualTo(SlackEventType.MEMBER_JOINED_CHANNEL);
     assertThat(event.getChannelType()).isEqualTo(ChannelType.GROUP);
     assertThat(ObjectMapperUtils.mapper().readValue(ObjectMapperUtils.mapper().writeValueAsString(event), SlackMemberJoinedChannelEvent.class)).isEqualTo(event);
+  }
+
+  @Test
+  public void itCanDeserMemberLeftPublicChannelEvent() throws IOException {
+    SlackMemberLeftChannelEvent event = fetchAndDeserializeSlackEvent("member_left_public_channel.json").toDetailedEvent();
+    assertThat(event.getType()).isEqualTo(SlackEventType.MEMBER_LEFT_CHANNEL);
+    assertThat(ObjectMapperUtils.mapper().readValue(ObjectMapperUtils.mapper().writeValueAsString(event), SlackMemberLeftChannelEvent.class)).isEqualTo(event);
+  }
+
+  @Test
+  public void itCanDeserMemberLeftPrivateChannelEvent() throws IOException {
+    SlackMemberLeftChannelEvent event = fetchAndDeserializeSlackEvent("member_left_public_channel.json").toDetailedEvent();
+    assertThat(event.getType()).isEqualTo(SlackEventType.MEMBER_LEFT_CHANNEL);
+    assertThat(ObjectMapperUtils.mapper().readValue(ObjectMapperUtils.mapper().writeValueAsString(event), SlackMemberLeftChannelEvent.class)).isEqualTo(event);
   }
 
   @Test

--- a/slack-base/src/test/resources/member_left_private_channel.json
+++ b/slack-base/src/test/resources/member_left_private_channel.json
@@ -1,0 +1,19 @@
+{
+  "token": "redacted",
+  "team_id": "redacted",
+  "api_app_id": "redacted",
+  "event": {
+    "type": "member_left_channel",
+    "user": "redacted",
+    "channel": "redacted",
+    "channel_type": "G",
+    "team": "redacted",
+    "event_ts": "1540822163.000100"
+  },
+  "type": "event_callback",
+  "event_id": "GvDQSNUMRY",
+  "event_time": 1540822163,
+  "authed_users": [
+    "redacted"
+  ]
+}

--- a/slack-base/src/test/resources/member_left_public_channel.json
+++ b/slack-base/src/test/resources/member_left_public_channel.json
@@ -1,0 +1,19 @@
+{
+  "token": "redacted",
+  "team_id": "redacted",
+  "api_app_id": "redacted",
+  "event": {
+    "type": "member_left_channel",
+    "user": "redacted",
+    "channel": "redacted",
+    "channel_type": "C",
+    "team": "redacted",
+    "event_ts": "1540822163.000100"
+  },
+  "type": "event_callback",
+  "event_id": "FvDQSNTLQY",
+  "event_time": 1540822163,
+  "authed_users": [
+    "redacted"
+  ]
+}


### PR DESCRIPTION
Need to deal with [member_left_channel](https://api.slack.com/events/member_left_channel) Slack event. Added model for it.