### PR TITLE
Add method to get paginated user.conversations

### DIFF
--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClient.java
@@ -182,6 +182,7 @@ public interface SlackClient extends Closeable {
   Iterable<CompletableFuture<Result<List<Conversation>, SlackError>>> listConversations(ConversationsListParams params);
   CompletableFuture<Result<ConversationListResponse, SlackError>> listConversationsPaginated(ConversationsListParams params);
   Iterable<CompletableFuture<Result<List<Conversation>, SlackError>>> usersConversations(ConversationsUserParams params);
+  CompletableFuture<Result<ConversationListResponse, SlackError>> usersConversationsPaginated(ConversationsUserParams params);
   CompletableFuture<Result<ConversationsCreateResponse, SlackError>> createConversation(ConversationCreateParams params);
   CompletableFuture<Result<ConversationsInviteResponse, SlackError>> inviteToConversation(ConversationInviteParams params);
   CompletableFuture<Result<ConversationsUnarchiveResponse, SlackError>> unarchiveConversation(ConversationUnarchiveParams params);

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
@@ -834,6 +834,13 @@ public class SlackWebClient implements SlackClient {
   }
 
   @Override
+  public CompletableFuture<Result<ConversationListResponse, SlackError>> usersConversationsPaginated(
+      ConversationsUserParams params
+  ) {
+    return postSlackCommand(SlackMethods.users_conversations, params, ConversationListResponse.class);
+  }
+
+  @Override
   public CompletableFuture<Result<ConversationsCreateResponse, SlackError>> createConversation(
     ConversationCreateParams params
   ) {


### PR DESCRIPTION
Added method to get user.conversations with pagination to be able to handle rate limit errors in slack HubsSpot integration.