### PR TITLE
Adding a method to SlackClient to get UserProfile

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/users/UsersProfileResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/users/UsersProfileResponseIF.java
@@ -3,15 +3,12 @@ package com.hubspot.slack.client.models.response.users;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;
 import com.hubspot.slack.client.models.users.UserProfile;
 
 @Immutable
 @HubSpotStyle
-@JsonNaming(SnakeCaseStrategy.class)
 public interface UsersProfileResponseIF extends SlackResponse {
   @JsonProperty("profile")
   UserProfile getUserProfile();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/users/UsersProfileResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/users/UsersProfileResponseIF.java
@@ -2,11 +2,17 @@ package com.hubspot.slack.client.models.response.users;
 
 import org.immutables.value.Value.Immutable;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;
+import com.hubspot.slack.client.models.users.UserProfile;
 
 @Immutable
 @HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
 public interface UsersProfileResponseIF extends SlackResponse {
-  UsersProfileResponse getUserProfile();
+  @JsonProperty("profile")
+  UserProfile getUserProfile();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/users/UsersProfileResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/users/UsersProfileResponseIF.java
@@ -1,0 +1,12 @@
+package com.hubspot.slack.client.models.response.users;
+
+import org.immutables.value.Value.Immutable;
+
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.response.SlackResponse;
+
+@Immutable
+@HubSpotStyle
+public interface UsersProfileResponseIF extends SlackResponse {
+  UsersProfileResponse getUserProfile();
+}

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClient.java
@@ -98,6 +98,7 @@ import com.hubspot.slack.client.models.response.usergroups.UsergroupUpdateRespon
 import com.hubspot.slack.client.models.response.usergroups.users.UsergroupUsersUpdateResponse;
 import com.hubspot.slack.client.models.response.users.UsersInfoResponse;
 import com.hubspot.slack.client.models.response.users.UsersListResponse;
+import com.hubspot.slack.client.models.response.users.UsersProfileResponse;
 import com.hubspot.slack.client.models.response.views.HomeTabViewCommandResponse;
 import com.hubspot.slack.client.models.response.views.ModalViewCommandResponse;
 import com.hubspot.slack.client.models.usergroups.SlackUsergroup;
@@ -114,6 +115,7 @@ public interface SlackClient extends Closeable {
   CompletableFuture<Result<FindRepliesResponse, SlackError>> findReplies(FindRepliesParams params);
   CompletableFuture<Result<UsersInfoResponse, SlackError>> findUser(UsersInfoParams params);
   CompletableFuture<Result<UsersInfoResponse, SlackError>> lookupUserByEmail(UserEmailParams email);
+  CompletableFuture<Result<UsersProfileResponse, SlackError>> getUserProfile(UsersInfoParams params);
 
   // users
   Iterable<CompletableFuture<Result<List<SlackUser>, SlackError>>> listUsers();

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
@@ -133,6 +133,7 @@ import com.hubspot.slack.client.models.response.usergroups.UsergroupUpdateRespon
 import com.hubspot.slack.client.models.response.usergroups.users.UsergroupUsersUpdateResponse;
 import com.hubspot.slack.client.models.response.users.UsersInfoResponse;
 import com.hubspot.slack.client.models.response.users.UsersListResponse;
+import com.hubspot.slack.client.models.response.users.UsersProfileResponse;
 import com.hubspot.slack.client.models.response.views.HomeTabViewCommandResponse;
 import com.hubspot.slack.client.models.response.views.ModalViewCommandResponse;
 import com.hubspot.slack.client.models.usergroups.SlackUsergroup;
@@ -426,6 +427,17 @@ public class SlackWebClient implements SlackClient {
     UsersInfoParams params
   ) {
     return postSlackCommand(SlackMethods.users_info, params, UsersInfoResponse.class);
+  }
+
+  @Override
+  public CompletableFuture<Result<UsersProfileResponse, SlackError>> getUserProfile(
+    UsersInfoParams params
+  ) {
+    return postSlackCommand(
+        SlackMethods.users_profile_get,
+        params,
+        UsersProfileResponse.class
+    );
   }
 
   @Override


### PR DESCRIPTION
This adds a method to the `SlackClient` to get the UserProfile using [users.profile.get](https://api.slack.com/methods/users.profile.get) Slack API.
Also adds a model to handle the response.

This is required for getting UserProfile fields in a new automation [(PR).](https://git.hubteam.com/HubSpot/Kepler/pull/1867)