### PR TITLE
Increase limit for elemets on Slack form

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/SlackDialogIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/SlackDialogIF.java
@@ -48,8 +48,8 @@ public interface SlackDialogIF {
       throw new IllegalStateException("At least one form element required");
     }
 
-    if (getElements().size() > 5) {
-      throw new IllegalStateException("At most 5 form elements allowed, got " + getElements().size());
+    if (getElements().size() > 10) {
+      throw new IllegalStateException("At most 10 form elements allowed, got " + getElements().size());
     }
 
     getState().ifPresent(state -> {


### PR DESCRIPTION
The number of allowed Slack form elements was recently increased from [5 to 10](https://api.slack.com/dialogs#recent_changes).
I need to have 6 elements on form I'm currently working on.