### PR TITLE
Update AbstractChatMessageParams.java

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractChatMessageParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractChatMessageParams.java
@@ -30,7 +30,7 @@ public abstract class AbstractChatMessageParams implements MessageParams {
   @Check
   public void check() {
     Preconditions.checkState((getText().isPresent() && !Strings.isNullOrEmpty(getText().get())) ||
-            !getAttachments().isEmpty(),
-        "Must include text if not providing attachments");
+            !getAttachments().isEmpty() || !getBlocks().isEmpty(),
+        "Must include text if not providing attachments or blocks");
   }
 }


### PR DESCRIPTION
If there are blocks, we can permit empty text.