### PR TITLE
Update to reflect that you can build a section with nothing but fields

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
@@ -1,5 +1,7 @@
 package com.hubspot.slack.client.models.blocks;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Preconditions;
@@ -9,12 +11,15 @@ import com.hubspot.slack.client.models.blocks.elements.BlockElement;
 import com.hubspot.slack.client.models.blocks.objects.Text;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Check;
+import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
 @Immutable
 @HubSpotStyle
+@JsonInclude(Include.NON_NULL)
 @JsonNaming(SnakeCaseStrategy.class)
 public interface SectionIF extends Block {
   String TYPE = "section";
@@ -25,8 +30,12 @@ public interface SectionIF extends Block {
     return TYPE;
   }
 
+  @Default
+  @Nullable
   @Value.Parameter
-  Optional<Text> getText();
+  default Text getText() {
+    return null;
+  }
 
   List<Text> getFields();
 
@@ -35,7 +44,7 @@ public interface SectionIF extends Block {
   @Check
   default void check() {
     boolean hasNonEmptyTextField =
-      getText().isPresent() && !Strings.isNullOrEmpty(getText().get().getText());
+      getText() != null && !Strings.isNullOrEmpty(getText().getText());
     boolean hasFields = !getFields().isEmpty();
     Preconditions.checkState(
       hasNonEmptyTextField || hasFields,

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
@@ -1,7 +1,5 @@
 package com.hubspot.slack.client.models.blocks;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Preconditions;
@@ -19,7 +17,6 @@ import org.immutables.value.Value.Immutable;
 
 @Immutable
 @HubSpotStyle
-@JsonInclude(Include.NON_NULL)
 @JsonNaming(SnakeCaseStrategy.class)
 public interface SectionIF extends Block {
   String TYPE = "section";

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
@@ -1,16 +1,17 @@
 package com.hubspot.slack.client.models.blocks;
 
-import java.util.List;
-import java.util.Optional;
-
-import org.immutables.value.Value;
-import org.immutables.value.Value.Immutable;
-
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.elements.BlockElement;
 import com.hubspot.slack.client.models.blocks.objects.Text;
+import java.util.List;
+import java.util.Optional;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Check;
+import org.immutables.value.Value.Immutable;
 
 @Immutable
 @HubSpotStyle
@@ -25,9 +26,20 @@ public interface SectionIF extends Block {
   }
 
   @Value.Parameter
-  Text getText();
+  Optional<Text> getText();
 
   List<Text> getFields();
 
   Optional<BlockElement> getAccessory();
+
+  @Check
+  default void check() {
+    boolean hasNonEmptyTextField =
+      getText().isPresent() && !Strings.isNullOrEmpty(getText().get().getText());
+    boolean hasFields = !getFields().isEmpty();
+    Preconditions.checkState(
+      hasNonEmptyTextField || hasFields,
+      "Must include text if not providing a list of fields"
+    );
+  }
 }


### PR DESCRIPTION
Slack's documentation states:

> The text for the block, in the form of a text object. Maximum length for the text in this field is 3000 characters. This field is not required if a valid array of fields objects is provided instead.

This PR allows you to either set text, or just provide a list of fields.

