### PR TITLE
Allow empty text if there is a list of attachments or blocks

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatPostEphemeralMessageParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatPostEphemeralMessageParamsIF.java
@@ -1,15 +1,13 @@
 package com.hubspot.slack.client.methods.params.chat;
 
-import java.util.Optional;
-
-import org.immutables.value.Value.Check;
-import org.immutables.value.Value.Default;
-import org.immutables.value.Value.Immutable;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.hubspot.immutables.style.HubSpotStyle;
+import java.util.Optional;
+import org.immutables.value.Value.Check;
+import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Immutable;
 
 @Immutable
 @HubSpotStyle
@@ -41,8 +39,11 @@ public interface ChatPostEphemeralMessageParamsIF extends MessageParams {
 
   @Check
   default void check() {
-    Preconditions.checkState((getText().isPresent() && !Strings.isNullOrEmpty(getText().get())) ||
-            !getAttachments().isEmpty(),
-        "Must include text if not providing attachments");
+    Preconditions.checkState(
+      (getText().isPresent() && !Strings.isNullOrEmpty(getText().get())) ||
+      !getAttachments().isEmpty() ||
+      !getBlocks().isEmpty(),
+      "Must include text if not providing attachments or blocks"
+    );
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatUpdateMessageParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatUpdateMessageParamsIF.java
@@ -1,11 +1,5 @@
 package com.hubspot.slack.client.methods.params.chat;
 
-import java.util.Optional;
-
-import org.immutables.value.Value.Check;
-import org.immutables.value.Value.Default;
-import org.immutables.value.Value.Immutable;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -14,6 +8,10 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.hubspot.immutables.style.HubSpotStyle;
+import java.util.Optional;
+import org.immutables.value.Value.Check;
+import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Immutable;
 
 @Immutable
 @HubSpotStyle
@@ -43,8 +41,11 @@ public interface ChatUpdateMessageParamsIF extends MessageParams {
 
   @Check
   default void check() {
-    Preconditions.checkState((getText().isPresent() && !Strings.isNullOrEmpty(getText().get())) ||
-            !getAttachments().isEmpty(),
-        "Must include text if not providing attachments");
+    Preconditions.checkState(
+      (getText().isPresent() && !Strings.isNullOrEmpty(getText().get())) ||
+      !getAttachments().isEmpty() ||
+      !getBlocks().isEmpty(),
+      "Must include text if not providing attachments or blocks"
+    );
   }
 }


### PR DESCRIPTION
Small update to make update/post ephemeral messages also allow sending pure attachment/block kit messages.