### PR TITLE
Optional view input values for ViewDatePickerIF and ViewPlainTextInputIF

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlocksLoadOptionsResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlocksLoadOptionsResponseIF.java
@@ -1,0 +1,23 @@
+package com.hubspot.slack.client.models.interaction;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.Option;
+import com.hubspot.slack.client.models.blocks.objects.OptionGroup;
+import org.immutables.value.Value.Immutable;
+
+import java.util.List;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface BlocksLoadOptionsResponseIF {
+  @JsonInclude(Include.NON_EMPTY)
+  List<Option> getOptions();
+
+  @JsonInclude(Include.NON_EMPTY)
+  List<OptionGroup> getOptionGroups();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/InteractiveCallbackType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/InteractiveCallbackType.java
@@ -10,6 +10,7 @@ public enum InteractiveCallbackType {
   MESSAGE_ACTION,
   BLOCK_ACTIONS,
   VIEW_SUBMISSION,
+  SHORTCUT,
   UNKNOWN
   ;
 

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ShortcutIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ShortcutIF.java
@@ -1,0 +1,18 @@
+package com.hubspot.slack.client.models.interaction;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.SlackChannel;
+import org.immutables.value.Value.Immutable;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ShortcutIF extends SlackInteractiveCallback {
+  String getTriggerId();
+
+  default SlackChannel getChannel() {
+    return null;
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/SlackInteractiveCallback.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/SlackInteractiveCallback.java
@@ -21,7 +21,8 @@ import com.hubspot.slack.client.models.users.SlackUserLite;
     @Type(value = InteractiveAction.class, name = "interactive_message"),
     @Type(value = DialogSubmission.class, name = "dialog_submission"),
     @Type(value = ViewSubmission.class, name = "view_submission"),
-    @Type(value = MessageAction.class, name = "message_action")
+    @Type(value = MessageAction.class, name = "message_action"),
+    @Type(value = Shortcut.class, name = "shortcut")
   }
 )
 public interface SlackInteractiveCallback {

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewDatePickerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewDatePickerIF.java
@@ -6,10 +6,11 @@ import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 @Value.Immutable
 @HubSpotStyle
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public interface ViewDatePickerIF extends ViewInput {
-  LocalDate getSelectedDate();
+  Optional<LocalDate> getSelectedDate();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewPlainTextInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewPlainTextInputIF.java
@@ -5,9 +5,11 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Immutable;
 
+import java.util.Optional;
+
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ViewPlainTextInputIF extends ViewInput {
-  String getValue();
+  Optional<String> getValue();
 }


### PR DESCRIPTION
Apologies in advance for the duplicate commits -- I screwed up my branch, but I think this will all merge fine once you get the other PR merged to master.

This change is just two small tweaks: I found that `ViewDatePickerIF` and`ViewPlainTextInputIF` could have null values in the real world. Per our previous discussion, I made these `Optional` since I figure the breaking change would be much smaller since it was two leaf node interfaces.