### PR TITLE
TopLevelMessageInteractionResponseIF can contain blocks

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlocksLoadOptionsResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlocksLoadOptionsResponseIF.java
@@ -1,0 +1,23 @@
+package com.hubspot.slack.client.models.interaction;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.Option;
+import com.hubspot.slack.client.models.blocks.objects.OptionGroup;
+import org.immutables.value.Value.Immutable;
+
+import java.util.List;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface BlocksLoadOptionsResponseIF {
+  @JsonInclude(Include.NON_EMPTY)
+  List<Option> getOptions();
+
+  @JsonInclude(Include.NON_EMPTY)
+  List<OptionGroup> getOptionGroups();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/InteractiveCallbackType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/InteractiveCallbackType.java
@@ -10,6 +10,7 @@ public enum InteractiveCallbackType {
   MESSAGE_ACTION,
   BLOCK_ACTIONS,
   VIEW_SUBMISSION,
+  SHORTCUT,
   UNKNOWN
   ;
 

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ShortcutIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ShortcutIF.java
@@ -1,0 +1,18 @@
+package com.hubspot.slack.client.models.interaction;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.SlackChannel;
+import org.immutables.value.Value.Immutable;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ShortcutIF extends SlackInteractiveCallback {
+  String getTriggerId();
+
+  default SlackChannel getChannel() {
+    return null;
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/SlackInteractiveCallback.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/SlackInteractiveCallback.java
@@ -21,7 +21,8 @@ import com.hubspot.slack.client.models.users.SlackUserLite;
     @Type(value = InteractiveAction.class, name = "interactive_message"),
     @Type(value = DialogSubmission.class, name = "dialog_submission"),
     @Type(value = ViewSubmission.class, name = "view_submission"),
-    @Type(value = MessageAction.class, name = "message_action")
+    @Type(value = MessageAction.class, name = "message_action"),
+    @Type(value = Shortcut.class, name = "shortcut")
   }
 )
 public interface SlackInteractiveCallback {

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/TopLevelMessageInteractionResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/TopLevelMessageInteractionResponseIF.java
@@ -3,6 +3,7 @@ package com.hubspot.slack.client.models.interaction;
 import java.util.List;
 import java.util.Optional;
 
+import com.hubspot.slack.client.models.blocks.Block;
 import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
@@ -29,6 +30,8 @@ public interface TopLevelMessageInteractionResponseIF {
   Optional<String> getText();
 
   List<Attachment> getAttachments();
+
+  List<Block> getBlocks();
 
   @Check
   default void check() {


### PR DESCRIPTION
Apologies in advance for the duplicate commits -- I screwed up my branch, but I think this will all merge fine once you get the other PR merged to master.

This PR is just a simple addition of `List<Block> getBlocks();` to `TopLevelMessageInteractionResponseIF` reflecting the reality that in addition to text or attachments, the response can also contain blocks.