### PR TITLE
Add OAuth credentials object for v2 Slack app

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/auth/OAuthV2CredentialsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/auth/OAuthV2CredentialsIF.java
@@ -15,19 +15,19 @@ import com.hubspot.slack.client.models.users.SlackUserLite;
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 public abstract class OAuthV2CredentialsIF {
-  public abstract String getAccessToken();
-
-  @JsonProperty("team")
-  public abstract SlackTeamLite getSlackTeamLite();
+  @JsonProperty("access_token")
+  public abstract String getBotAccessToken();
+  public abstract SlackTeamLite getTeam();
   public abstract Optional<String> getScope();
   public abstract SlackUserLite getAuthedUser();
+  public abstract String getBotUserId();
 
   public String getTeamId() {
-    return getSlackTeamLite().getId();
+    return getTeam().getId();
   }
 
   public String getTeamName() {
-    return getSlackTeamLite().getName();
+    return getTeam().getName();
   }
 
   public String getUserId () {

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/auth/OAuthV2CredentialsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/auth/OAuthV2CredentialsIF.java
@@ -30,7 +30,7 @@ public abstract class OAuthV2CredentialsIF {
     return getTeam().getName();
   }
 
-  public String getUserId () {
+  public String getUserId() {
     return getAuthedUser().getId();
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/auth/OAuthV2CredentialsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/auth/OAuthV2CredentialsIF.java
@@ -1,0 +1,38 @@
+package com.hubspot.slack.client.models.auth;
+
+import java.util.Optional;
+
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.teams.SlackTeamLite;
+import com.hubspot.slack.client.models.users.SlackUserLite;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public abstract class OAuthV2CredentialsIF {
+  public abstract String getAccessToken();
+
+  @JsonProperty("team")
+  public abstract SlackTeamLite getSlackTeamLite();
+  public abstract Optional<String> getScope();
+  public abstract SlackUserLite getAuthedUser();
+  public abstract Optional<BotCredentials> getBot();
+  public abstract Optional<IncomingWebhook> getIncomingWebhook();
+
+  public String getTeamId() {
+    return getSlackTeamLite().getId();
+  }
+
+  public String getTeamName() {
+    return getSlackTeamLite().getName();
+  }
+
+  public String getUserId () {
+    return getAuthedUser().getId();
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/auth/OAuthV2CredentialsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/auth/OAuthV2CredentialsIF.java
@@ -21,8 +21,6 @@ public abstract class OAuthV2CredentialsIF {
   public abstract SlackTeamLite getSlackTeamLite();
   public abstract Optional<String> getScope();
   public abstract SlackUserLite getAuthedUser();
-  public abstract Optional<BotCredentials> getBot();
-  public abstract Optional<IncomingWebhook> getIncomingWebhook();
 
   public String getTeamId() {
     return getSlackTeamLite().getId();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/teams/SlackTeamLiteIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/teams/SlackTeamLiteIF.java
@@ -1,0 +1,14 @@
+package com.hubspot.slack.client.models.teams;
+
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public interface SlackTeamLiteIF {
+  String getId();
+  String getName();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/teams/SlackTeamLiteIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/teams/SlackTeamLiteIF.java
@@ -2,12 +2,10 @@ package com.hubspot.slack.client.models.teams;
 
 import org.immutables.value.Value.Immutable;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.hubspot.immutables.style.HubSpotStyle;
 
 @Immutable
 @HubSpotStyle
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface SlackTeamLiteIF {
   String getId();
   String getName();


### PR DESCRIPTION
Object added in order to be able to deserialize response for [oauth.v2.access](https://api.slack.com/methods/oauth.v2.access) request which is used on Slack app installation to exchange temporary OAuth code for an API access token.
