### PR TITLE
Add models for group events

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventType.java
@@ -3,14 +3,19 @@ package com.hubspot.slack.client.models.events;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.hubspot.slack.client.enums.EnumIndex;
-import com.hubspot.slack.client.models.events.bot.SlackAppHomeOpenedEvent;
 import com.hubspot.slack.client.models.events.app.SlackAppUninstalledEvent;
 import com.hubspot.slack.client.models.events.app.SlackTokensRevokedEvent;
+import com.hubspot.slack.client.models.events.bot.SlackAppHomeOpenedEvent;
 import com.hubspot.slack.client.models.events.channel.SlackChannelArchiveEvent;
 import com.hubspot.slack.client.models.events.channel.SlackChannelCreatedEvent;
 import com.hubspot.slack.client.models.events.channel.SlackChannelDeletedEvent;
 import com.hubspot.slack.client.models.events.channel.SlackChannelRenameEvent;
 import com.hubspot.slack.client.models.events.channel.SlackChannelUnarchiveEvent;
+import com.hubspot.slack.client.models.events.group.SlackGroupArchiveEvent;
+import com.hubspot.slack.client.models.events.group.SlackGroupDeletedEvent;
+import com.hubspot.slack.client.models.events.group.SlackGroupOpenEvent;
+import com.hubspot.slack.client.models.events.group.SlackGroupRenameEvent;
+import com.hubspot.slack.client.models.events.group.SlackGroupUnarchiveEvent;
 import com.hubspot.slack.client.models.events.links.SlackLinkSharedEvent;
 import com.hubspot.slack.client.models.events.user.SlackMemberJoinedChannelEvent;
 import com.hubspot.slack.client.models.events.user.SlackMemberLeftChannelEvent;
@@ -42,12 +47,13 @@ public enum SlackEventType {
   FILE_UNSHARED,
   GRID_MIGRATION_FINISHED,
   GRID_MIGRATION_STARTED,
-  GROUP_ARCHIVE,
+  GROUP_ARCHIVE(SlackGroupArchiveEvent.class),
   GROUP_CLOSE,
   GROUP_HISTORY_CHANGED,
-  GROUP_OPEN,
-  GROUP_RENAME,
-  GROUP_UNARCHIVE,
+  GROUP_OPEN(SlackGroupOpenEvent.class),
+  GROUP_RENAME(SlackGroupRenameEvent.class),
+  GROUP_UNARCHIVE(SlackGroupUnarchiveEvent.class),
+  GROUP_DELETED(SlackGroupDeletedEvent.class),
   IM_CLOSE,
   IM_CREATED,
   IM_HISTORY_CHANGED,

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupArchiveEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupArchiveEventIF.java
@@ -15,4 +15,10 @@ import org.immutables.value.Value;
 public interface SlackGroupArchiveEventIF extends SlackEvent {
   @JsonProperty("channel")
   String getChannelId();
+
+  //Group archived events do not have a ts, so we manually set it as null
+  @Override
+  default String getTs() {
+    return null;
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupArchiveEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupArchiveEventIF.java
@@ -12,13 +12,5 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = SlackGroupArchiveEvent.class)
 @Value.Immutable
 @HubSpotStyle
-public interface SlackGroupArchiveEventIF extends SlackEvent {
-  @JsonProperty("channel")
-  String getChannelId();
-
-  //Group archived events do not have a ts, so we manually set it as null
-  @Override
-  default String getTs() {
-    return null;
-  }
+public interface SlackGroupArchiveEventIF extends SlackGroupEventCore {
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupArchiveEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupArchiveEventIF.java
@@ -1,0 +1,18 @@
+package com.hubspot.slack.client.models.events.group;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.events.SlackEvent;
+import org.immutables.value.Value;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackGroupArchiveEvent.class)
+@Value.Immutable
+@HubSpotStyle
+public interface SlackGroupArchiveEventIF extends SlackEvent {
+  @JsonProperty("channel")
+  String getChannelId();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupDeletedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupDeletedEventIF.java
@@ -12,13 +12,5 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = SlackGroupDeletedEvent.class)
 @Value.Immutable
 @HubSpotStyle
-public interface SlackGroupDeletedEventIF extends SlackEvent {
-  @JsonProperty("channel")
-  String getChannelId();
-
-  //Group deleted events do not have a ts, so we manually set it as null
-  @Override
-  default String getTs() {
-    return null;
-  }
+public interface SlackGroupDeletedEventIF extends SlackGroupEventCore {
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupDeletedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupDeletedEventIF.java
@@ -15,4 +15,10 @@ import org.immutables.value.Value;
 public interface SlackGroupDeletedEventIF extends SlackEvent {
   @JsonProperty("channel")
   String getChannelId();
+
+  //Group deleted events do not have a ts, so we manually set it as null
+  @Override
+  default String getTs() {
+    return null;
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupDeletedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupDeletedEventIF.java
@@ -1,0 +1,18 @@
+package com.hubspot.slack.client.models.events.group;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.events.SlackEvent;
+import org.immutables.value.Value;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackGroupDeletedEvent.class)
+@Value.Immutable
+@HubSpotStyle
+public interface SlackGroupDeletedEventIF extends SlackEvent {
+  @JsonProperty("channel")
+  String getChannelId();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupEventCore.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupEventCore.java
@@ -1,0 +1,15 @@
+package com.hubspot.slack.client.models.events.group;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hubspot.slack.client.models.events.SlackEvent;
+
+public interface SlackGroupEventCore extends SlackEvent {
+    @JsonProperty("channel")
+    String getChannelId();
+
+    //Group events do not have a ts, so we manually set it as null
+    @Override
+    default String getTs() {
+        return null;
+    }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupOpenEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupOpenEventIF.java
@@ -1,0 +1,21 @@
+package com.hubspot.slack.client.models.events.group;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.events.SlackEvent;
+import org.immutables.value.Value;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackGroupOpenEvent.class)
+@Value.Immutable
+@HubSpotStyle
+public interface SlackGroupOpenEventIF extends SlackEvent {
+  @JsonProperty("channel")
+  String getChannelId();
+
+  @JsonProperty("user")
+  String getUserId();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupOpenEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupOpenEventIF.java
@@ -12,16 +12,7 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = SlackGroupOpenEvent.class)
 @Value.Immutable
 @HubSpotStyle
-public interface SlackGroupOpenEventIF extends SlackEvent {
-  @JsonProperty("channel")
-  String getChannelId();
-
+public interface SlackGroupOpenEventIF extends SlackGroupEventCore {
   @JsonProperty("user")
   String getUserId();
-
-  //Group open events do not have a ts, so we manually set it as null
-  @Override
-  default String getTs() {
-    return null;
-  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupOpenEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupOpenEventIF.java
@@ -18,4 +18,10 @@ public interface SlackGroupOpenEventIF extends SlackEvent {
 
   @JsonProperty("user")
   String getUserId();
+
+  //Group open events do not have a ts, so we manually set it as null
+  @Override
+  default String getTs() {
+    return null;
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupRenameEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupRenameEventIF.java
@@ -1,0 +1,17 @@
+package com.hubspot.slack.client.models.events.group;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.SlackChannel;
+import com.hubspot.slack.client.models.events.SlackEvent;
+import org.immutables.value.Value;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackGroupRenameEvent.class)
+@Value.Immutable
+@HubSpotStyle
+public interface SlackGroupRenameEventIF extends SlackEvent {
+  SlackChannel getChannel();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupRenameEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupRenameEventIF.java
@@ -14,4 +14,10 @@ import org.immutables.value.Value;
 @HubSpotStyle
 public interface SlackGroupRenameEventIF extends SlackEvent {
   SlackChannel getChannel();
+
+  //Group rename events do not have a ts, so we manually set it as null
+  @Override
+  default String getTs() {
+    return null;
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupUnarchiveEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupUnarchiveEventIF.java
@@ -12,13 +12,5 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = SlackGroupUnarchiveEvent.class)
 @Value.Immutable
 @HubSpotStyle
-public interface SlackGroupUnarchiveEventIF extends SlackEvent {
-  @JsonProperty("channel")
-  String getChannelId();
-
-  //Group unarchived events do not have a ts, so we manually set it as null
-  @Override
-  default String getTs() {
-    return null;
-  }
+public interface SlackGroupUnarchiveEventIF extends SlackGroupEventCore {
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupUnarchiveEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupUnarchiveEventIF.java
@@ -15,4 +15,10 @@ import org.immutables.value.Value;
 public interface SlackGroupUnarchiveEventIF extends SlackEvent {
   @JsonProperty("channel")
   String getChannelId();
+
+  //Group unarchived events do not have a ts, so we manually set it as null
+  @Override
+  default String getTs() {
+    return null;
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupUnarchiveEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupUnarchiveEventIF.java
@@ -1,0 +1,18 @@
+package com.hubspot.slack.client.models.events.group;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.events.SlackEvent;
+import org.immutables.value.Value;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackGroupUnarchiveEvent.class)
+@Value.Immutable
+@HubSpotStyle
+public interface SlackGroupUnarchiveEventIF extends SlackEvent {
+  @JsonProperty("channel")
+  String getChannelId();
+}


### PR DESCRIPTION
As slack actually sends us a lot more events, then we have now, and to satisfy need of having consumed events from private channels (so-called groups in the Slack API), this PR contains a few added models, which are also binded with the SlackEventType enum entries.

PR is ready for review.