### PR TITLE
Add user access token to OAuth credentials model for V2 app

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/auth/OAuthV2CredentialsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/auth/OAuthV2CredentialsIF.java
@@ -33,4 +33,8 @@ public abstract class OAuthV2CredentialsIF {
   public String getUserId() {
     return getAuthedUser().getId();
   }
+
+  public String getUserAccessToken() {
+    return getAuthedUser().getAccessToken().get();
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/users/SlackUserLiteIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/users/SlackUserLiteIF.java
@@ -1,5 +1,7 @@
 package com.hubspot.slack.client.models.users;
 
+import java.util.Optional;
+
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
@@ -10,5 +12,7 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 public interface SlackUserLiteIF extends SlackUserCore {
+
+  Optional<String> getAccessToken();
 
 }

--- a/slack-base/src/test/resources/block_actions.json
+++ b/slack-base/src/test/resources/block_actions.json
@@ -6,7 +6,8 @@
   },
   "user": {
     "id": "USER_ID",
-    "name": "auser"
+    "name": "auser",
+    "access_token": "xoxp-507412329303-981238771351-1412370955013-fce9dc6b782f54549b5b2d435afe229e"
   },
   "token": "ITS_A_SECRET",
   "trigger_id": "869524640327.819832772087.67c795e952f7b500a9cd55d2d1830d6c",


### PR DESCRIPTION
In addition to bot token, we need to store user access token from Slack token request (oauth.v2.access) response on app installation.`OAuthV2CredentialsIF` model needs to be updated to get this token.