### PR TITLE
Update group and channel models. Add general SlackConversationEventCore model.

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelArchiveEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelArchiveEventIF.java
@@ -1,5 +1,6 @@
 package com.hubspot.slack.client.models.events.channel;
 
+import com.hubspot.slack.client.models.events.conversation.SlackConversationEventCore;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -7,22 +8,12 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
-import com.hubspot.slack.client.models.events.SlackEvent;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackChannelArchiveEvent.class)
-public interface SlackChannelArchiveEventIF extends SlackEvent {
-  @JsonProperty("channel")
-  String getChannelId();
-
+public interface SlackChannelArchiveEventIF extends SlackConversationEventCore {
   @JsonProperty("user")
   String getUserId();
-
-  //Channel archive events do not have a ts, so we manually set it as null
-  @Override
-  default String getTs() {
-    return null;
-  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelCreatedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelCreatedEventIF.java
@@ -1,28 +1,16 @@
 package com.hubspot.slack.client.models.events.channel;
 
+import com.hubspot.slack.client.models.events.conversation.SlackConversationEventWithChannel;
 import org.immutables.value.Value.Immutable;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
-import com.hubspot.slack.client.models.SlackChannel;
-import com.hubspot.slack.client.models.events.SlackEvent;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackChannelCreatedEvent.class)
-public interface SlackChannelCreatedEventIF extends SlackEvent {
-  //Channel.created and channel.creator do not exist on the SlackChannel object and consequently aren't parsed right now. If we need these in the future
-  //we can define a wrapper around SlackChannel containing those two fields.
-
-  SlackChannel getChannel();
-
-  //Channel created events do not have a ts, so we manually set it as null
-  @Override
-  default String getTs() {
-    return null;
-  }
+public interface SlackChannelCreatedEventIF extends SlackConversationEventWithChannel {
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelDeletedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelDeletedEventIF.java
@@ -1,25 +1,16 @@
 package com.hubspot.slack.client.models.events.channel;
 
+import com.hubspot.slack.client.models.events.conversation.SlackConversationEventCore;
 import org.immutables.value.Value.Immutable;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
-import com.hubspot.slack.client.models.events.SlackEvent;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackChannelDeletedEvent.class)
-public interface SlackChannelDeletedEventIF extends SlackEvent {
-  @JsonProperty("channel")
-  String getChannelId();
-
-  //Channel deleted events do not have a ts, so we manually set it as null
-  @Override
-  default String getTs() {
-    return null;
-  }
+public interface SlackChannelDeletedEventIF extends SlackConversationEventCore {
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelRenameEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelRenameEventIF.java
@@ -1,27 +1,18 @@
 package com.hubspot.slack.client.models.events.channel;
 
+import com.hubspot.slack.client.models.events.conversation.SlackConversationEventWithChannel;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
-import com.hubspot.slack.client.models.SlackChannel;
-import com.hubspot.slack.client.models.events.SlackEvent;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackChannelRenameEvent.class)
-public interface SlackChannelRenameEventIF extends SlackEvent {
+public interface SlackChannelRenameEventIF extends SlackConversationEventWithChannel {
   //Channel.created does not exist on the SlackChannel object and consequently isn't parsed right now. If we need this in the future
   //we can define a wrapper around SlackChannel containing that field
-
-  SlackChannel getChannel();
-
-  //Channel rename events do not have a ts, so we manually set it as null
-  @Override
-  default String getTs() {
-    return null;
-  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelUnarchiveEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelUnarchiveEventIF.java
@@ -1,5 +1,6 @@
 package com.hubspot.slack.client.models.events.channel;
 
+import com.hubspot.slack.client.models.events.conversation.SlackConversationEventCore;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -7,22 +8,12 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
-import com.hubspot.slack.client.models.events.SlackEvent;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackChannelUnarchiveEvent.class)
-public interface SlackChannelUnarchiveEventIF extends SlackEvent {
-  @JsonProperty("channel")
-  String getChannelId();
-
+public interface SlackChannelUnarchiveEventIF extends SlackConversationEventCore {
   @JsonProperty("user")
   String getUnarchivedByUserId();
-
-  //Channel unarchive events do not have a ts, so we manually set it as null
-  @Override
-  default String getTs() {
-    return null;
-  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/conversation/SlackConversationEventCore.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/conversation/SlackConversationEventCore.java
@@ -1,13 +1,13 @@
-package com.hubspot.slack.client.models.events.group;
+package com.hubspot.slack.client.models.events.conversation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hubspot.slack.client.models.events.SlackEvent;
 
-public interface SlackGroupEventCore extends SlackEvent {
+public interface SlackConversationEventCore extends SlackEvent {
     @JsonProperty("channel")
     String getChannelId();
 
-    //Group events do not have a ts, so we manually set it as null
+    //Conversation events do not have a ts, so we manually set it as null
     @Override
     default String getTs() {
         return null;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/conversation/SlackConversationEventWithChannel.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/conversation/SlackConversationEventWithChannel.java
@@ -1,0 +1,15 @@
+package com.hubspot.slack.client.models.events.conversation;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.hubspot.slack.client.models.SlackChannel;
+import org.immutables.value.Value;
+
+public interface SlackConversationEventWithChannel extends SlackConversationEventCore {
+    SlackChannel getChannel();
+
+    @JsonIgnore
+    @Value.Derived
+    default String getChannelId() {
+        return getChannel().getId();
+    }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupArchiveEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupArchiveEventIF.java
@@ -1,16 +1,15 @@
 package com.hubspot.slack.client.models.events.group;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
-import com.hubspot.slack.client.models.events.SlackEvent;
+import com.hubspot.slack.client.models.events.conversation.SlackConversationEventCore;
 import org.immutables.value.Value;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackGroupArchiveEvent.class)
 @Value.Immutable
 @HubSpotStyle
-public interface SlackGroupArchiveEventIF extends SlackGroupEventCore {
+public interface SlackGroupArchiveEventIF extends SlackConversationEventCore {
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupDeletedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupDeletedEventIF.java
@@ -1,16 +1,15 @@
 package com.hubspot.slack.client.models.events.group;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
-import com.hubspot.slack.client.models.events.SlackEvent;
+import com.hubspot.slack.client.models.events.conversation.SlackConversationEventCore;
 import org.immutables.value.Value;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackGroupDeletedEvent.class)
 @Value.Immutable
 @HubSpotStyle
-public interface SlackGroupDeletedEventIF extends SlackGroupEventCore {
+public interface SlackGroupDeletedEventIF extends SlackConversationEventCore {
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupOpenEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupOpenEventIF.java
@@ -5,14 +5,14 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
-import com.hubspot.slack.client.models.events.SlackEvent;
+import com.hubspot.slack.client.models.events.conversation.SlackConversationEventCore;
 import org.immutables.value.Value;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackGroupOpenEvent.class)
 @Value.Immutable
 @HubSpotStyle
-public interface SlackGroupOpenEventIF extends SlackGroupEventCore {
+public interface SlackGroupOpenEventIF extends SlackConversationEventCore {
   @JsonProperty("user")
   String getUserId();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupRenameEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupRenameEventIF.java
@@ -4,20 +4,12 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
-import com.hubspot.slack.client.models.SlackChannel;
-import com.hubspot.slack.client.models.events.SlackEvent;
+import com.hubspot.slack.client.models.events.conversation.SlackConversationEventWithChannel;
 import org.immutables.value.Value;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackGroupRenameEvent.class)
 @Value.Immutable
 @HubSpotStyle
-public interface SlackGroupRenameEventIF extends SlackEvent {
-  SlackChannel getChannel();
-
-  //Group rename events do not have a ts, so we manually set it as null
-  @Override
-  default String getTs() {
-    return null;
-  }
+public interface SlackGroupRenameEventIF extends SlackConversationEventWithChannel {
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupUnarchiveEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupUnarchiveEventIF.java
@@ -1,16 +1,15 @@
 package com.hubspot.slack.client.models.events.group;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
-import com.hubspot.slack.client.models.events.SlackEvent;
+import com.hubspot.slack.client.models.events.conversation.SlackConversationEventCore;
 import org.immutables.value.Value;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackGroupUnarchiveEvent.class)
 @Value.Immutable
 @HubSpotStyle
-public interface SlackGroupUnarchiveEventIF extends SlackGroupEventCore {
+public interface SlackGroupUnarchiveEventIF extends SlackConversationEventCore {
 }

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/events/json/EventDeserializerTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/events/json/EventDeserializerTest.java
@@ -1,12 +1,5 @@
 package com.hubspot.slack.client.models.events.json;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-
-import org.junit.Test;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.hubspot.slack.client.jackson.ObjectMapperUtils;
 import com.hubspot.slack.client.models.ChannelType;
@@ -18,6 +11,12 @@ import com.hubspot.slack.client.models.events.links.SlackLinkSharedEvent;
 import com.hubspot.slack.client.models.events.user.SlackMemberJoinedChannelEvent;
 import com.hubspot.slack.client.models.events.user.SlackMemberLeftChannelEvent;
 import com.hubspot.slack.client.models.events.user.SlackUserChangeEvent;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class EventDeserializerTest {
   @Test
@@ -99,6 +98,36 @@ public class EventDeserializerTest {
   }
 
   @Test
+  public void itCanDeserializeGroupArchiveEvent() throws IOException {
+    SlackEvent event = fetchAndDeserializeSlackEvent("group_archive_event.json");
+    assertThat(event.getType()).isEqualTo(SlackEventType.GROUP_ARCHIVE);
+  }
+
+  @Test
+  public void itCanDeserializeGroupDeletedEvent() throws IOException {
+    SlackEvent event = fetchAndDeserializeSlackEvent("group_deleted_event.json");
+    assertThat(event.getType()).isEqualTo(SlackEventType.GROUP_DELETED);
+  }
+
+  @Test
+  public void itCanDeserializeGroupOpenEvent() throws IOException {
+    SlackEvent event = fetchAndDeserializeSlackEvent("group_open_event.json");
+    assertThat(event.getType()).isEqualTo(SlackEventType.GROUP_OPEN);
+  }
+
+  @Test
+  public void itCanDeserializeGroupRenameEvent() throws IOException {
+    SlackEvent event = fetchAndDeserializeSlackEvent("group_rename_event.json");
+    assertThat(event.getType()).isEqualTo(SlackEventType.GROUP_RENAME);
+  }
+
+  @Test
+  public void itCanDeserializeGroupUnArchiveEvent() throws IOException {
+    SlackEvent event = fetchAndDeserializeSlackEvent("group_unarchive_event.json");
+    assertThat(event.getType()).isEqualTo(SlackEventType.GROUP_UNARCHIVE);
+  }
+
+  @Test
   public void itCanDeserMemberJoinedChannelEventWithoutInviter() throws IOException {
     SlackMemberJoinedChannelEvent event = fetchAndDeserializeSlackEvent("member_joined_channel.json").toDetailedEvent();
     assertThat(event.getType()).isEqualTo(SlackEventType.MEMBER_JOINED_CHANNEL);
@@ -164,9 +193,10 @@ public class EventDeserializerTest {
 
   private SlackEvent deserializeSlackEvent(String rawJson) throws IOException {
     SlackEventWrapper<? extends SlackEvent> eventWrapper = ObjectMapperUtils.mapper().readValue(
-        rawJson, new TypeReference<SlackEventWrapper<? extends SlackEvent>>() {
-        }
+            rawJson, new TypeReference<SlackEventWrapper<? extends SlackEvent>>() {
+            }
     );
     return eventWrapper.getEvent().toDetailedEvent();
   }
 }
+

--- a/slack-base/src/test/resources/group_archive_event.json
+++ b/slack-base/src/test/resources/group_archive_event.json
@@ -1,0 +1,16 @@
+{
+  "token": "uWopedqK86MJfjUeq8v9pUAD",
+  "team_id": "redacted",
+  "api_app_id": "redacted",
+  "event": {
+    "type": "group_archive",
+    "channel": "GCX8BFXED",
+    "event_ts": "1537542788.000200"
+  },
+  "type": "event_callback",
+  "event_id": "EvCYA72LVA",
+  "event_time": 1537542788,
+  "authed_users": [
+    "UBRFHDFGA"
+  ]
+}

--- a/slack-base/src/test/resources/group_deleted_event.json
+++ b/slack-base/src/test/resources/group_deleted_event.json
@@ -1,0 +1,16 @@
+{
+  "token": "uWopedqK86MJfjUeq8v9pUAD",
+  "team_id": "redacted",
+  "api_app_id": "redacted",
+  "event": {
+    "type": "group_deleted",
+    "channel": "GCXCZNATW",
+    "event_ts": "1537468216.000200"
+  },
+  "type": "event_callback",
+  "event_id": "EvCY17K7QD",
+  "event_time": 1537468216,
+  "authed_users": [
+    "UBRFHDFGA"
+  ]
+}

--- a/slack-base/src/test/resources/group_open_event.json
+++ b/slack-base/src/test/resources/group_open_event.json
@@ -1,0 +1,17 @@
+{
+  "token": "uWopedqK86MJfjUeq8v9pUAD",
+  "team_id": "redacted",
+  "api_app_id": "redacted",
+  "event": {
+    "type": "group_open",
+    "channel": "GCXF9BDV1",
+    "user": "UBRFHDFGA",
+    "event_ts": "1537452804.000100"
+  },
+  "type": "event_callback",
+  "event_id": "EvCXCPK952",
+  "event_time": 1537452804,
+  "authed_users": [
+    "UBRFHDFGA"
+  ]
+}

--- a/slack-base/src/test/resources/group_rename_event.json
+++ b/slack-base/src/test/resources/group_rename_event.json
@@ -1,0 +1,20 @@
+{
+  "token": "uWopedqK86MJfjUeq8v9pUAD",
+  "team_id": "redacted",
+  "api_app_id": "redacted",
+  "event": {
+    "type": "group_rename",
+    "channel": {
+      "id": "GCX8BFXED",
+      "name": "knightwhosayni",
+      "created": 1537468268
+    },
+    "event_ts": "1537543256.000100"
+  },
+  "type": "event_callback",
+  "event_id": "EvCXQ1LM0Q",
+  "event_time": 1537543256,
+  "authed_users": [
+    "UBRFHDFGA"
+  ]
+}

--- a/slack-base/src/test/resources/group_unarchive_event.json
+++ b/slack-base/src/test/resources/group_unarchive_event.json
@@ -1,0 +1,17 @@
+{
+  "token": "uWopedqK86MJfjUeq8v9pUAD",
+  "team_id": "redacted",
+  "api_app_id": "redacted",
+  "event": {
+    "type": "group_unarchive",
+    "channel": "GCX8BFXED",
+    "user": "UBRFHDFGA",
+    "event_ts": "1537543598.000200"
+  },
+  "type": "event_callback",
+  "event_id": "EvCYD468UB",
+  "event_time": 1537543598,
+  "authed_users": [
+    "UBRFHDFGA"
+  ]
+}


### PR DESCRIPTION
While working with this repo, I've discovered, that there are actually no general parent class, which will combine channel and group events, besides SlackEvent. 
For purposes of better compatibility, SlackConversationEventCore has been introduced.
Also, adding SlackConversationEventWithChannel, for those events, which require usage of full SlackChannel object, not only the id.