### PR TITLE
Prevent NPEs in SectionIF check

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
@@ -43,11 +43,11 @@ public interface SectionIF extends Block {
     boolean hasNonEmptyTextField =
       getText() != null && !Strings.isNullOrEmpty(getText().getText());
     boolean hasFields = !getFields().isEmpty();
+    Preconditions.checkState(
+        hasNonEmptyTextField || hasFields,
+        "Must include text if not providing a list of fields"
+    );
     boolean isTextLengthValid = getText().getText().length() <= 3000;
     Preconditions.checkState(isTextLengthValid, "The text length of a Section block cannot exceed 3000 characters");
-    Preconditions.checkState(
-      hasNonEmptyTextField || hasFields,
-      "Must include text if not providing a list of fields"
-    );
   }
 }


### PR DESCRIPTION
Currently, we are fetching text length `isTextLengthValid` before we check if the text is null and this results in an unnecessary NPE. This PR fixes the order of the checks.