### PR TITLE
Fix NPE possibility in SectionIF

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
@@ -47,7 +47,9 @@ public interface SectionIF extends Block {
         hasNonEmptyTextField || hasFields,
         "Must include text if not providing a list of fields"
     );
-    boolean isTextLengthValid = getText().getText().length() <= 3000;
-    Preconditions.checkState(isTextLengthValid, "The text length of a Section block cannot exceed 3000 characters");
+    if (hasNonEmptyTextField) {
+      boolean isTextLengthValid = getText().getText().length() <= 3000;
+      Preconditions.checkState(isTextLengthValid, "The text length of a Section block cannot exceed 3000 characters");
+    }
   }
 }


### PR DESCRIPTION
## Updates
In SectionIF.java, `text` can be null as long as there are fields present. For this case, `getText().getText()` would throw an NPE, and this is currently happening at the validation step. 

To address the above, I added a condition to only perform the second Precondition check if `text` is not null. 