### PR TITLE
Use conversations_replies instead of channels_replies

### DIFF
--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
@@ -291,7 +291,7 @@ public class SlackWebClient implements SlackClient {
         );
       case CHANNEL:
         return postSlackCommand(
-          SlackMethods.channels_replies,
+          SlackMethods.conversations_replies,
           params,
           FindRepliesResponse.class
         );


### PR DESCRIPTION
channels_replies has been deprecated as of Feb 24th: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api

Conversations API doc: https://api.slack.com/methods/conversations.replies

It seems the response format is the same, so the same parsing should continue to work.

@szabowexler @kecarroll 