### PR TITLE
Update SectionIF.java

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
@@ -41,13 +41,17 @@ public interface SectionIF extends Block {
   @Check
   default void check() {
     boolean hasNonEmptyTextField =
-      (getText() != null && !Strings.isNullOrEmpty(getText().getText())) || (getFields().stream().allMatch(item -> !Strings.isNullOrEmpty(item.getText())));
+      getText() != null && !Strings.isNullOrEmpty(getText().getText());
     boolean hasFields = !getFields().isEmpty();
     Preconditions.checkState(
         hasNonEmptyTextField || hasFields,
         "Must include text if not providing a list of fields"
     );
-    boolean isTextLengthValid = getText().getText().length() <= 3000;
-    Preconditions.checkState(isTextLengthValid, "The text length of a Section block cannot exceed 3000 characters");
+    boolean fieldsTextLengthValid = hasFields && getFields().stream().allMatch(item -> item.getText().length() <= 3000);
+    boolean textLengthValid = getText() != null && getText().getText().length() <= 3000;
+    Preconditions.checkState(
+        textLengthValid || fieldsTextLengthValid,
+        "The text length of a Section block cannot exceed 3000 characters"
+    );
   }
 }


### PR DESCRIPTION
one more update - turns out, fields are covered in the hasFields check. in debugger, found the null pointer is happening during the isTextLengthValid check. updated check to not break (null pointer excp) and to check fields text length