### PR TITLE
Update SlackTextFileCore.java

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackTextFileCore.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackTextFileCore.java
@@ -10,5 +10,5 @@ public interface SlackTextFileCore extends SlackFile {
   Optional<String> getLinesMore();
 
   @JsonProperty("preview_is_truncated")
-  boolean isPreviewTruncated();
+  Optional<Boolean> isPreviewTruncated();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackTextFileCore.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackTextFileCore.java
@@ -3,11 +3,11 @@ package com.hubspot.slack.client.models.files;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public interface SlackTextFileCore extends SlackFile {
-  String getEditLink();
-  String getPreview();
-  String getPreviewHighlight();
-  String getLines();
-  String getLinesMore();
+  Optional<String> getEditLink();
+  Optional<String> getPreview();
+  Optional<String> getPreviewHighlight();
+  Optional<String> getLines();
+  Optional<String> getLinesMore();
 
   @JsonProperty("preview_is_truncated")
   boolean isPreviewTruncated();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackTextFileCore.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackTextFileCore.java
@@ -1,6 +1,7 @@
 package com.hubspot.slack.client.models.files;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Optional;
 
 public interface SlackTextFileCore extends SlackFile {
   Optional<String> getEditLink();


### PR DESCRIPTION
seeing these fields can be null while fetching conversationHistory for a given channel
error: Cannot build SlackCsvFile, some of required attributes are not set [editLink, preview, previewHighlight, lines, linesMore, previewTruncated]