### PR TITLE
send slack token properly

### DIFF
--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
@@ -1,5 +1,22 @@
 package com.hubspot.slack.client;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
@@ -148,21 +165,6 @@ import com.hubspot.slack.client.paging.AbstractPagedIterable;
 import com.hubspot.slack.client.paging.LazyLoadingPage;
 import com.hubspot.slack.client.ratelimiting.ByMethodRateLimiter;
 import com.hubspot.slack.client.ratelimiting.SlackRateLimiter;
-import java.io.File;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class SlackWebClient implements SlackClient {
   public static final int RATE_LIMIT_SENTINEL_VALUE = -1;
@@ -1579,11 +1581,11 @@ public class SlackWebClient implements SlackClient {
     Class<T> responseType
   ) {
     HttpRequest.Builder requestBuilder = buildBaseSlackPost(method)
-      .setContentType(ContentType.FORM);
+      .setContentType(ContentType.FORM)
+      .addHeader("Authorization", "Bearer " + config.getTokenSupplier().get());
     params
       .entries()
       .forEach(param -> requestBuilder.setFormParam(param.getKey()).to(param.getValue()));
-    requestBuilder.setQueryParam("token").to(config.getTokenSupplier().get());
     return executeLoggedAs(method, requestBuilder.build(), responseType);
   }
 


### PR DESCRIPTION
https://api.slack.com/changelog/2020-11-no-more-tokens-in-querystrings-for-newly-created-apps

New apps currently can't use these methods.

We need to start sending all the tokens as Auth headers and not query params.