### PR TITLE
Add integration test for ChatDeleteParams model

### DIFF
--- a/slack-base/src/test/java/com/hubspot/slack/client/methods/params/chat/ChatDeleteParamsTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/methods/params/chat/ChatDeleteParamsTest.java
@@ -1,0 +1,23 @@
+package com.hubspot.slack.client.methods.params.chat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.hubspot.slack.client.SerializationTestBase;
+import com.hubspot.slack.client.jackson.ObjectMapperUtils;
+
+public class ChatDeleteParamsTest extends SerializationTestBase {
+
+  @Test
+  public void itDoesntSerializeAsUserFieldIfItContainsDefaultValue() throws IOException {
+    ChatDeleteParams chatDeleteParams = ChatDeleteParams.builder()
+        .setChannelId("C1234567890")
+        .setMessageToDeleteTs("123456789.9875")
+        .build();
+    String chatDeleteParamsSerialized = ObjectMapperUtils.mapper().writeValueAsString(chatDeleteParams);
+    assertThat(chatDeleteParamsSerialized).doesNotContain("as_user");
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/methods/params/chat/ChatDeleteParamsTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/methods/params/chat/ChatDeleteParamsTest.java
@@ -20,4 +20,15 @@ public class ChatDeleteParamsTest extends SerializationTestBase {
     String chatDeleteParamsSerialized = ObjectMapperUtils.mapper().writeValueAsString(chatDeleteParams);
     assertThat(chatDeleteParamsSerialized).doesNotContain("as_user");
   }
+
+  @Test
+  public void itSerializesAsUserFieldIfItEquelsTrue() throws IOException {
+    ChatDeleteParams chatDeleteParams = ChatDeleteParams.builder()
+        .setChannelId("C1234567890")
+        .setMessageToDeleteTs("123456789.9875")
+        .setAsUser(true)
+        .build();
+    String chatDeleteParamsSerialized = ObjectMapperUtils.mapper().writeValueAsString(chatDeleteParams);
+    assertThat(chatDeleteParamsSerialized).contains("as_user");
+  }
 }


### PR DESCRIPTION
Add integration test for `ChatDeleteParams` model to ensure that `as_user` param is not sent to Slack if it contains default value (`false`).
Slack doesn't allow to include `as_user` param in case if requests are executed by new granular bot. 