### PR TITLE
Update to newer immutables version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   </modules>
 
   <properties>
-    <dep.immutables.version>2.2.10</dep.immutables.version>
+    <dep.immutables.version>2.2.12</dep.immutables.version>
     <dep.netty3.version>3.10.6.Final</dep.netty3.version>
     <dep.slf4j.version>1.7.26</dep.slf4j.version>
   </properties>


### PR DESCRIPTION
This updated the pinned immutables version to a slightly newer one which has the org.immutables:encode dep available. This is part of the rollout of https://github.com/HubSpot/hubspot-immutables/pull/19