### PR TITLE
Fix 'No serializer found for class java.lang.Object' on getTeamInfo method execution

### DIFF
--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
@@ -1389,7 +1389,7 @@ public class SlackWebClient implements SlackClient {
 
   @Override
   public CompletableFuture<Result<TeamInfoResponse, SlackError>> getTeamInfo() {
-    return postSlackCommand(SlackMethods.team_info, new Object(), TeamInfoResponse.class);
+    return postSlackCommand(SlackMethods.team_info, Collections.emptyMap(), TeamInfoResponse.class);
   }
 
   @Override


### PR DESCRIPTION
`ObjectMapper` fails to serialize an instance of class `Object`. Because of this `getTeamInfo` method fails with 'No serializer found for class java.lang.Object'. since it passes `new Object()` as a `params` field to the `postSlackCommand` method. This PR fixes this by passing an empty map instead of the object's instance.