### PR TITLE
Add team name to SlackTeam model

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/team/TeamInfoResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/team/TeamInfoResponseIF.java
@@ -2,6 +2,7 @@ package com.hubspot.slack.client.models.response.team;
 
 import org.immutables.value.Value.Immutable;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;
 import com.hubspot.slack.client.models.teams.SlackTeam;
@@ -9,5 +10,6 @@ import com.hubspot.slack.client.models.teams.SlackTeam;
 @Immutable
 @HubSpotStyle
 public interface TeamInfoResponseIF extends SlackResponse {
+  @JsonProperty("team")
   SlackTeam getSlackTeam();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/teams/SlackTeamIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/teams/SlackTeamIF.java
@@ -13,7 +13,7 @@ import com.hubspot.immutables.style.HubSpotStyle;
 public interface SlackTeamIF {
   String getId();
   String getDomain();
-  String getName();
+  Optional<String> getName();
   Optional<String> getEnterpriseId();
   Optional<String> getEnterpriseName();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/teams/SlackTeamIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/teams/SlackTeamIF.java
@@ -13,6 +13,7 @@ import com.hubspot.immutables.style.HubSpotStyle;
 public interface SlackTeamIF {
   String getId();
   String getDomain();
+  String getName();
   Optional<String> getEnterpriseId();
   Optional<String> getEnterpriseName();
 }

--- a/slack-base/src/test/resources/block_actions.json
+++ b/slack-base/src/test/resources/block_actions.json
@@ -2,6 +2,7 @@
   "type": "block_actions",
   "team": {
     "id": "TEAM_ID",
+    "name": "TEAM_NAME",
     "domain": "slackhubspoti-et16299"
   },
   "user": {

--- a/slack-base/src/test/resources/dialog_submission.json
+++ b/slack-base/src/test/resources/dialog_submission.json
@@ -9,6 +9,7 @@
   "callback_id": "KEPLER_PAGE_ONCALL_FINISHED_FORM",
   "team": {
     "id": "T024G0P55",
+    "name": "team_name",
     "domain": "hubspot"
   },
   "user": {

--- a/slack-base/src/test/resources/interactive_button_click.json
+++ b/slack-base/src/test/resources/interactive_button_click.json
@@ -10,6 +10,7 @@
   "callback_id": "test",
   "team": {
     "id": "T024G0P55",
+    "name": "team_name",
     "domain": "hubspot"
   },
   "channel": {

--- a/slack-base/src/test/resources/interactive_load_options_req.json
+++ b/slack-base/src/test/resources/interactive_load_options_req.json
@@ -5,6 +5,7 @@
   "callback_id": "kepler",
   "team": {
     "id": "T024G0P55",
+    "name": "team_name",
     "domain": "hubspot"
   },
   "channel": {

--- a/slack-base/src/test/resources/view_submission.json
+++ b/slack-base/src/test/resources/view_submission.json
@@ -2,6 +2,7 @@
   "type": "view_submission",
   "team": {
     "id": "id1",
+    "name": "team_name",
     "domain": "hubspot"
   },
   "user": {


### PR DESCRIPTION
Added Slack team name to `SlackTeam` model to be able to get team name with [team.info](https://api.slack.com/methods/team.info#response) method.
Also, the `team.info` response doesn't contain the property `slack_team`. The corresponding JSON property is named `team`. This was fixed in the `TeamInfoResponse` model.