### PR TITLE
Add `restricted_action` error type

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorType.java
@@ -60,6 +60,7 @@ public enum SlackErrorType {
 
   REQUEST_TIMEOUT("request_timeout"),
   RATE_LIMITED("ratelimited"),
+  RESTRICTED_ACTION("restricted_action"),
 
   TEAM_ADDED_TO_ORG("team_added_to_org"),
   TOO_MANY_ATTACHMENTS("too_many_attachments"),


### PR DESCRIPTION
[conversations.create](https://api.slack.com/methods/conversations.create) API  returns this error if `a team preference prevents the authenticated user from creating channels`.