### PR TITLE
Specify java distribution for GH action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v2.1.0
       with:
+        distribution: 'adopt'
         java-version: ${{ matrix.java }}
     - name: print Java version
       run: java -version


### PR DESCRIPTION
It's required in `setup-java@v2.1.0`