### PR TITLE
Add reactions to conversation history

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/LiteMessageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/LiteMessageIF.java
@@ -35,6 +35,8 @@ public interface LiteMessageIF {
 
   List<Block> getBlocks();
 
+  List<Reaction> getReactions();
+
   @JsonProperty("ts")
   String getTimestamp();
 

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/ReactionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/ReactionIF.java
@@ -3,6 +3,8 @@ package com.hubspot.slack.client.models;
 import java.util.List;
 
 import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -11,9 +13,10 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ReactionIF {
+  @JsonProperty("name")
   String getName();
-
+  @JsonProperty("count")
   Integer getCount();
-
+  @JsonProperty("users")
   List<String> getUser();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/ReactionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/ReactionIF.java
@@ -1,0 +1,19 @@
+package com.hubspot.slack.client.models;
+
+import java.util.List;
+
+import org.immutables.value.Value.Immutable;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ReactionIF {
+  String getName();
+
+  Integer getCount();
+
+  List<String> getUser();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/ReactionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/ReactionIF.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.immutables.value.Value.Immutable;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -13,10 +12,7 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ReactionIF {
-  @JsonProperty("name")
   String getName();
-  @JsonProperty("count")
-  Integer getCount();
-  @JsonProperty("users")
-  List<String> getUser();
+  int getCount();
+  List<String> getUsers();
 }

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/response/conversations/ConversationsRepliesResponseTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/response/conversations/ConversationsRepliesResponseTest.java
@@ -36,7 +36,9 @@ public class ConversationsRepliesResponseTest {
     assertThat(response.getMessages().get(1).getReactions().size()).isEqualTo(2);
     assertThat(response.getMessages().get(1).getReactions().get(0).getName()).isEqualTo("astonished");
     assertThat(response.getMessages().get(1).getReactions().get(0).getCount()).isEqualTo(3);
-    assertThat(response.getMessages().get(3).getReactions().get(1).getUsers()).isEqualTo(Arrays.asList("U061F7AUR", "U062F7AUR", "U063F7AUR"));
+    assertThat(response.getMessages().get(1).getReactions().get(1).getName()).isEqualTo("facepalm");
+    assertThat(response.getMessages().get(1).getReactions().get(1).getCount()).isEqualTo(34);
+    assertThat(response.getMessages().get(1).getReactions().get(1).getUsers()).isEqualTo(Arrays.asList("U061F7AUR", "U062F7AUR", "U063F7AUR", "U064F7AUR", "U065F7AUR"));
   }
 
   @Test

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/response/conversations/ConversationsRepliesResponseTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/response/conversations/ConversationsRepliesResponseTest.java
@@ -33,6 +33,10 @@ public class ConversationsRepliesResponseTest {
     assertThat(response.getMessages().get(0).getReplyUserIds().get()).isEqualTo(Arrays.asList("U061F7AUR", "U061F7AUR", "U061F7AUR"));
     assertThat(response.getMessages().get(0).getReplyUsersCount().get()).isEqualTo(3);
     assertThat(response.getMessages().get(0).getLatestReplyTimestamp().get()).isEqualTo("1483125339.020269");
+    assertThat(response.getMessages().get(1).getReactions().size()).isEqualTo(2);
+    assertThat(response.getMessages().get(1).getReactions().get(0).getName()).isEqualTo("astonished");
+    assertThat(response.getMessages().get(1).getReactions().get(0).getCount()).isEqualTo(3);
+    assertThat(response.getMessages().get(3).getReactions().get(1).getUsers()).isEqualTo(Arrays.asList("U061F7AUR", "U062F7AUR", "U063F7AUR"));
   }
 
   @Test

--- a/slack-base/src/test/resources/conversations.replies.with_replies_and_new_fields.json
+++ b/slack-base/src/test/resources/conversations.replies.with_replies_and_new_fields.json
@@ -35,7 +35,19 @@
       "text": "Shutters shut and shutters and so shutters shut and shutters and so and so shutters and so shutters shut and so shutters shut and shutters and so.",
       "thread_ts": "1482960137.003543",
       "parent_user_id": "U061F7AUR",
-      "ts": "1483037603.017503"
+      "ts": "1483037603.017503",
+      "reactions": [
+        {
+          "name": "astonished",
+          "count": 3,
+          "users": [ "U061F7AUR", "U062F7AUR", "U063F7AUR"]
+        },
+        {
+          "name": "facepalm",
+          "count": 34,
+          "users": [ "U061F7AUR", "U062F7AUR", "U063F7AUR", "U064F7AUR", "U065F7AUR" ]
+        }
+      ]
     },
     {
       "type": "message",
@@ -51,7 +63,19 @@
       "text": "I love you Alice B. Toklas and so does Gertrude Stein.",
       "thread_ts": "1482960137.003543",
       "parent_user_id": "U061F7AUR",
-      "ts": "1483125339.020269"
+      "ts": "1483125339.020269",
+      "reactions": [
+        {
+          "name": "grin",
+          "count": 2,
+          "users": [ "U061F7AUR", "U062F7AUR"]
+        },
+        {
+          "name": "wink",
+          "count": 50,
+          "users": [ "U061F7AUR", "U062F7AUR", "U063F7AUR" ]
+        }
+      ]
     }
   ],
   "has_more": true,

--- a/slack-base/src/test/resources/conversations.replies.with_replies_and_new_fields.json
+++ b/slack-base/src/test/resources/conversations.replies.with_replies_and_new_fields.json
@@ -63,19 +63,7 @@
       "text": "I love you Alice B. Toklas and so does Gertrude Stein.",
       "thread_ts": "1482960137.003543",
       "parent_user_id": "U061F7AUR",
-      "ts": "1483125339.020269",
-      "reactions": [
-        {
-          "name": "grin",
-          "count": 2,
-          "users": [ "U061F7AUR", "U062F7AUR"]
-        },
-        {
-          "name": "wink",
-          "count": 50,
-          "users": [ "U061F7AUR", "U062F7AUR", "U063F7AUR" ]
-        }
-      ]
+      "ts": "1483125339.020269"
     }
   ],
   "has_more": true,


### PR DESCRIPTION
Added reactions to the `LiteMessage` model to be able to retrieve the list or reactions attached to a slack message.