### PR TITLE
edit git depth in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
   "language": "java",
   "jdk": "oraclejdk8",
   "git": {
-    "depth": 100
+    "depth": 3
   },
   "sudo": false,
   "addons": {


### PR DESCRIPTION
According to [git-clone-depth](https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth), Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.