### PR TITLE
Add `thread_ts` field to bot messages

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/AbstractSlackEventBotMessage.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/AbstractSlackEventBotMessage.java
@@ -21,6 +21,8 @@ public abstract class AbstractSlackEventBotMessage extends SlackEventMessageBase
   @JsonProperty("channel")
   public abstract String getChannelId();
 
+  public abstract Optional<String> getThreadTs();
+
   public abstract Optional<String> getText();
   public abstract List<Attachment> getAttachments();
   public abstract String getBotId();


### PR DESCRIPTION
Checking for an optional thread timestamp is how you verify if a message was posted in a thread or not. Without this you cannot disambiguate top level bot messages from threaded bot messages

@szabowexler 