### PR TITLE
Moving token from query param to form param

### DIFF
--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
@@ -1583,7 +1583,7 @@ public class SlackWebClient implements SlackClient {
     params
       .entries()
       .forEach(param -> requestBuilder.setFormParam(param.getKey()).to(param.getValue()));
-    requestBuilder.setQueryParam("token").to(config.getTokenSupplier().get());
+    requestBuilder.addHeader("Authorization", "Bearer " + config.getTokenSupplier().get());
     return executeLoggedAs(method, requestBuilder.build(), responseType);
   }
 


### PR DESCRIPTION
Newly created slack apps no longer allow auth to be passed as a query param. This change removes the only spot where the hubspot slack client does so. On the reclaim side this only affects get/set of slack user profile.