### PR TITLE
Add subtype for conversations-select input

### DIFF
--- a/slack-base/pom.xml
+++ b/slack-base/pom.xml
@@ -11,10 +11,10 @@
   <artifactId>slack-base</artifactId>
 
   <dependencies>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>org.slf4j</groupId>-->
+<!--      <artifactId>slf4j-api</artifactId>-->
+<!--    </dependency>-->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>

--- a/slack-base/pom.xml
+++ b/slack-base/pom.xml
@@ -11,10 +11,6 @@
   <artifactId>slack-base</artifactId>
 
   <dependencies>
-<!--    <dependency>-->
-<!--      <groupId>org.slf4j</groupId>-->
-<!--      <artifactId>slf4j-api</artifactId>-->
-<!--    </dependency>-->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
@@ -78,6 +74,11 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationSelectMenuIF.java
@@ -35,4 +35,14 @@ public interface ConversationSelectMenuIF extends BlockElement, HasActionId {
 
   @JsonProperty("confirm")
   Optional<ConfirmationDialog> getConfirmationDialog();
+
+  @Value.Derived
+  default boolean getResponseUrlEnabled() {
+    return true;
+  }
+
+  @Value.Derived
+  default boolean getDefaultToCurrentConversation() {
+    return true;
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ConversationsSelectMenuInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ConversationsSelectMenuInputIF.java
@@ -1,0 +1,16 @@
+package com.hubspot.slack.client.models.interaction.views;
+
+import java.util.Optional;
+
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ConversationsSelectMenuInputIF extends ViewInput {
+  Optional<String> getSelectedConversation();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewConversationsSelectIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewConversationsSelectIF.java
@@ -11,6 +11,6 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface ConversationsSelectMenuInputIF extends ViewInput {
+public interface ViewConversationsSelectIF extends ViewInput {
   Optional<String> getSelectedConversation();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewInput.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewInput.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
     @Type(value = ViewRadioButtonGroup.class, name = "radio_buttons"),
     @Type(value = UsersSelectInput.class, name = "users_select"),
     @Type(value = ViewCheckboxes.class, name = "checkboxes"),
-    @Type(value = ConversationsSelectMenuInput.class, name = "conversations_select")
+    @Type(value = ViewConversationsSelect.class, name = "conversations_select")
   }
 )
 public interface ViewInput {

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewInput.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewInput.java
@@ -21,7 +21,8 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
     @Type(value = ViewDatePicker.class, name = "datepicker"),
     @Type(value = ViewRadioButtonGroup.class, name = "radio_buttons"),
     @Type(value = UsersSelectInput.class, name = "users_select"),
-    @Type(value = ViewCheckboxes.class, name = "checkboxes")
+    @Type(value = ViewCheckboxes.class, name = "checkboxes"),
+    @Type(value = ConversationsSelectMenuInput.class, name = "conversations_select")
   }
 )
 public interface ViewInput {

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewInputType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewInputType.java
@@ -10,6 +10,7 @@ public enum ViewInputType {
   RADIO_BUTTONS,
   USERS_SELECT,
   CHECKBOXES,
+  CONVERSATIONS_SELECT,
   UNKNOWN;
 
   private static final EnumIndex<String, ViewInputType> INDEX = new EnumIndex<>(

--- a/slack-base/src/test/resources/block_elements.json
+++ b/slack-base/src/test/resources/block_elements.json
@@ -254,6 +254,8 @@
   {
     "action_id": "text1234",
     "type": "conversations_select",
+    "response_url_enabled": true,
+    "default_to_current_conversation": true,
     "placeholder": {
       "type": "plain_text",
       "text": "Select an item"


### PR DESCRIPTION
Added [fields](https://api.slack.com/surfaces/modals/using#modal_response_url) for `ConversationsSelectMenu` model to receive channel id in the View Submission. Also added subtype of `ViewInput` type for the conversations-select input object unmarshalling.

Context: when the user selects the channel from [Conversations list](https://api.slack.com/reference/block-kit/block-elements#conversation_select) on the model, Slack sends are `conversations-select` object in the view submission `state` field (please see example below). In order to get the select channel, we need to have a corresponding model.
```
{
  "type": "view_submission",
    .
    .
    .
    "callback_id": "callbackId",
    "state": {
      "values": {
       .
       .
       .
        "cdA=j": {
          "conversation-select": {
            "type": "conversations_select",
            "selected_conversation": "CHANNELID"
          }
        }
      }
    },
    "hash": "hash",
    "title": {
``` 