### PR TITLE
Normalize Slack form element presentational data

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackDialogFormTextElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackDialogFormTextElement.java
@@ -22,23 +22,20 @@ public abstract class AbstractSlackDialogFormTextElement extends SlackDialogForm
 
   public abstract Optional<String> getValue();
 
-  protected void validateBaseTextElementProps() {
-
-    super.validateBaseElementProperties();
-    if (getMinLength() < 0) {
-      throw new IllegalStateException("Min length cannot be negative, got " + getMinLength());
+  protected void validateBaseTextElementProps(AbstractSlackDialogFormTextElement normalized) {
+    super.validateBaseElementProperties(normalized);
+    int normalizedMinLength = normalized.getMinLength();
+    if (normalizedMinLength < 0) {
+      throw new IllegalStateException("Min length cannot be negative, got " + normalizedMinLength);
     }
 
-    if (getMaxLength() < 0) {
-      throw new IllegalStateException("Max length cannot be negative, got " + getMaxLength());
+    int normalizedMaxLength = normalized.getMaxLength();
+    if (normalizedMaxLength < 0) {
+      throw new IllegalStateException("Max length cannot be negative, got " + normalizedMaxLength);
     }
 
-    if (getMinLength() > getMaxLength()) {
-      throw new IllegalStateException("Min length must be <= max length, got " + getMinLength() + ", " + getMaxLength());
-    }
-
-    if (getHint().isPresent() && getHint().get().length() > 150) {
-      throw new IllegalStateException("Hint cannot exceed 150 chars, got '" + getHint().get() + "'");
+    if (normalizedMinLength > normalizedMaxLength) {
+      throw new IllegalStateException("Min length must be <= max length, got " + normalizedMinLength + ", " + normalizedMaxLength);
     }
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormSelectElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormSelectElement.java
@@ -16,13 +16,13 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.actions.SlackDataSource;
 import com.hubspot.slack.client.models.dialog.form.SlackFormElementTypes;
-import com.hubspot.slack.client.models.dialog.form.elements.helper.SlackDialogElementNormalizer;
+import com.hubspot.slack.client.models.dialog.form.elements.helpers.SlackDialogElementNormalizer;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 @JsonInclude(Include.NON_EMPTY)
-public abstract class AbstractSlackFormSelectElement extends SlackDialogFormElement {
+public abstract class AbstractSlackFormSelectElement extends SlackDialogFormElement implements HasOptions {
   @Default
   @Override
   public SlackFormElementTypes getType() {
@@ -34,7 +34,6 @@ public abstract class AbstractSlackFormSelectElement extends SlackDialogFormElem
     return SlackDataSource.STATIC;
   }
 
-  public abstract List<SlackFormOption> getOptions();
   public abstract List<SlackFormOptionGroup> getOptionGroups();
   public abstract Optional<String> getValue();
   public abstract List<SlackFormOption> getSelectedOptions();
@@ -51,12 +50,14 @@ public abstract class AbstractSlackFormSelectElement extends SlackDialogFormElem
     List<SlackFormOptionGroup> normalizedOptionGroups = normalized.getOptionGroups();
     int numOptionGroups = normalizedOptionGroups.size();
 
-    if (numOptions > SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER.getLimit()) {
-      errors.add("Cannot have more than 100 options");
+    int maxOptionsNumber = SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER.getLimit();
+    if (numOptions > maxOptionsNumber) {
+      errors.add(String.format("Cannot have more than %s options", maxOptionsNumber));
     }
 
-    if (numOptionGroups > SlackDialogFormElementLengthLimits.MAX_OPTION_GROUPS_NUMBER.getLimit()) {
-      errors.add("Cannot have more than 100 option groups");
+    int maxOptionGroupsNumber = SlackDialogFormElementLengthLimits.MAX_OPTION_GROUPS_NUMBER.getLimit();
+    if (numOptionGroups > maxOptionGroupsNumber) {
+      errors.add(String.format("Cannot have more than %s option groups", maxOptionGroupsNumber));
     }
 
     if (normalized.getDataSource().equals(SlackDataSource.STATIC)) {

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormSelectElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormSelectElement.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.actions.SlackDataSource;
 import com.hubspot.slack.client.models.dialog.form.SlackFormElementTypes;
+import com.hubspot.slack.client.models.dialog.form.elements.helper.SlackDialogElementNormalizer;
 
 @Immutable
 @HubSpotStyle
@@ -40,56 +41,61 @@ public abstract class AbstractSlackFormSelectElement extends SlackDialogFormElem
   public abstract Optional<Integer> getMinQueryLength();
 
   @Check
-  public void validate() {
-    super.validateBaseElementProperties();
+  public AbstractSlackFormSelectElement validate() {
+    AbstractSlackFormSelectElement normalized = SlackDialogElementNormalizer.normalize(this);
+    super.validateBaseElementProperties(normalized);
     List<String> errors = new ArrayList<>();
 
-    int numOptions = getOptions().size();
-    int numOptionGroups = getOptionGroups().size();
+    List<SlackFormOption> normalizedOptions = normalized.getOptions();
+    int numOptions = normalizedOptions.size();
+    List<SlackFormOptionGroup> normalizedOptionGroups = normalized.getOptionGroups();
+    int numOptionGroups = normalizedOptionGroups.size();
 
-    if (numOptions > 100) {
+    if (numOptions > SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER.getLimit()) {
       errors.add("Cannot have more than 100 options");
     }
 
-    if (numOptionGroups > 100) {
+    if (numOptionGroups > SlackDialogFormElementLengthLimits.MAX_OPTION_GROUPS_NUMBER.getLimit()) {
       errors.add("Cannot have more than 100 option groups");
     }
 
-    if (getDataSource().equals(SlackDataSource.STATIC)) {
+    if (normalized.getDataSource().equals(SlackDataSource.STATIC)) {
       if (numOptions == 0 && numOptionGroups == 0) {
         errors.add("Either options or option groups are required for static data source types");
       }
     }
 
-    if (getValue().isPresent() && getDataSource().equals(SlackDataSource.EXTERNAL)) {
+    Optional<String> normalizedValue = normalized.getValue();
+    if (normalizedValue.isPresent() && normalized.getDataSource().equals(SlackDataSource.EXTERNAL)) {
       errors.add("Cannot use value for external data source, must use selected options");
     }
 
-    if (getValue().isPresent()) {
+    if (normalizedValue.isPresent()) {
       boolean valueIsSomeOptionValue = getOptions().stream()
-          .anyMatch(option -> option.getValue().equalsIgnoreCase(getValue().get()));
+          .anyMatch(option -> option.getValue().equalsIgnoreCase(normalizedValue.get()));
       if (!valueIsSomeOptionValue) {
         errors.add("Value must exactly match the value field for one provided option");
       }
     }
 
-    if (!getSelectedOptions().isEmpty()) {
-      if (getSelectedOptions().size() != 1) {
+    List<SlackFormOption> normalizedSelectedOptions = normalized.getSelectedOptions();
+    if (!normalizedSelectedOptions.isEmpty()) {
+      if (normalizedSelectedOptions.size() != 1) {
         errors.add("Selected options must be a single element array");
       }
-      if (!getOptionGroups().isEmpty()) {
-        boolean selectedOptionIsInOptionsGroup = getOptionGroups().stream()
+      if (!normalizedOptionGroups.isEmpty()) {
+        boolean selectedOptionIsInOptionsGroup = normalizedOptionGroups.stream()
             .map(SlackFormOptionGroup::getOptions)
             .collect(Collectors.toList())
             .stream()
             .flatMap(List::stream)
-            .anyMatch(option -> option.equals(getSelectedOptions().get(0)));
+            .anyMatch(option -> option.equals(normalizedSelectedOptions.get(0)));
         if (!selectedOptionIsInOptionsGroup) {
           errors.add("Selected option must exactly match an option in the provided options groups");
         }
-      } else if (!getOptions().isEmpty()) {
-        boolean selectedOptionIsInOptions = getOptions().stream()
-            .anyMatch(option -> option.equals(getSelectedOptions().get(0)));
+      } else if (!normalizedOptions.isEmpty()) {
+        boolean selectedOptionIsInOptions = normalizedOptions.stream()
+            .anyMatch(option -> option.equals(normalizedSelectedOptions.get(0)));
         if (!selectedOptionIsInOptions) {
           errors.add("Selected option must exactly match an option in the provided options");
         }
@@ -99,5 +105,6 @@ public abstract class AbstractSlackFormSelectElement extends SlackDialogFormElem
     if (!errors.isEmpty()) {
       throw new IllegalStateException(errors.toString());
     }
+    return normalized;
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextElement.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.dialog.form.SlackFormElementTypes;
-import com.hubspot.slack.client.models.dialog.form.elements.helper.SlackDialogElementNormalizer;
+import com.hubspot.slack.client.models.dialog.form.elements.helpers.SlackDialogElementNormalizer;
 
 @Immutable
 @HubSpotStyle
@@ -31,18 +31,22 @@ public abstract class AbstractSlackFormTextElement extends AbstractSlackDialogFo
     super.validateBaseTextElementProps(normalized);
 
     int normalizedMaxLength = normalized.getMaxLength();
-    if (normalizedMaxLength > SlackDialogFormElementLengthLimits.MAX_TEXT_ELEMENT_VALUE_LENGTH.getLimit()) {
-      throw new IllegalStateException("Form text element cannot have max length > 150 chars, got " + normalizedMaxLength);
+    int maxTextElementValueLength = SlackDialogFormElementLengthLimits.MAX_TEXT_ELEMENT_VALUE_LENGTH.getLimit();
+    if (normalizedMaxLength > maxTextElementValueLength) {
+      String errorMessage = String.format("Form text element cannot have max length > %s chars, got %s", maxTextElementValueLength, normalizedMaxLength);
+      throw new IllegalStateException(errorMessage);
     }
 
     int normalizedMinLength = normalized.getMinLength();
-    if (normalizedMinLength > SlackDialogFormElementLengthLimits.MAX_TEXT_ELEMENT_VALUE_LENGTH.getLimit()) {
-      throw new IllegalStateException("Form text element cannot have min length > 150 chars, got " + normalizedMinLength);
+    if (normalizedMinLength > maxTextElementValueLength) {
+      String errorMessage = String.format("Form text element cannot have min length > %s chars, got %s", maxTextElementValueLength, normalizedMinLength);
+      throw new IllegalStateException(errorMessage);
     }
 
     Optional<String> value = normalized.getValue();
-    if (value.isPresent() && value.get().length() > SlackDialogFormElementLengthLimits.MAX_TEXT_ELEMENT_VALUE_LENGTH.getLimit()) {
-      throw new IllegalStateException("Value cannot exceed 150 chars, got '" + value.get() + "'");
+    if (value.isPresent() && value.get().length() > maxTextElementValueLength) {
+      String errorMessage = String.format("Value cannot exceed %s chars, got %s", maxTextElementValueLength, value.get());
+      throw new IllegalStateException(errorMessage);
     }
     return normalized;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextElement.java
@@ -1,5 +1,7 @@
 package com.hubspot.slack.client.models.dialog.form.elements;
 
+import java.util.Optional;
+
 import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
@@ -10,6 +12,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.dialog.form.SlackFormElementTypes;
+import com.hubspot.slack.client.models.dialog.form.elements.helper.SlackDialogElementNormalizer;
 
 @Immutable
 @HubSpotStyle
@@ -23,19 +26,24 @@ public abstract class AbstractSlackFormTextElement extends AbstractSlackDialogFo
   }
 
   @Check
-  public void validate() {
-    super.validateBaseTextElementProps();
+  public AbstractSlackFormTextElement validate() {
+    AbstractSlackFormTextElement normalized = SlackDialogElementNormalizer.normalize(this);
+    super.validateBaseTextElementProps(normalized);
 
-    if (getMaxLength() > 150) {
-      throw new IllegalStateException("Form text element cannot have max length > 150 chars, got " + getMaxLength());
+    int normalizedMaxLength = normalized.getMaxLength();
+    if (normalizedMaxLength > SlackDialogFormElementLengthLimits.MAX_TEXT_ELEMENT_VALUE_LENGTH.getLimit()) {
+      throw new IllegalStateException("Form text element cannot have max length > 150 chars, got " + normalizedMaxLength);
     }
 
-    if (getMinLength() > 150) {
-      throw new IllegalStateException("Form text element cannot have min length > 150 chars, got " + getMinLength());
+    int normalizedMinLength = normalized.getMinLength();
+    if (normalizedMinLength > SlackDialogFormElementLengthLimits.MAX_TEXT_ELEMENT_VALUE_LENGTH.getLimit()) {
+      throw new IllegalStateException("Form text element cannot have min length > 150 chars, got " + normalizedMinLength);
     }
 
-    if (getValue().isPresent() && getValue().get().length() > 150) {
-      throw new IllegalStateException("Value cannot exceed 150 chars, got '" + getValue().get() + "'");
+    Optional<String> value = normalized.getValue();
+    if (value.isPresent() && value.get().length() > SlackDialogFormElementLengthLimits.MAX_TEXT_ELEMENT_VALUE_LENGTH.getLimit()) {
+      throw new IllegalStateException("Value cannot exceed 150 chars, got '" + value.get() + "'");
     }
+    return normalized;
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextareaElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextareaElement.java
@@ -1,5 +1,7 @@
 package com.hubspot.slack.client.models.dialog.form.elements;
 
+import java.util.Optional;
+
 import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
@@ -10,6 +12,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.dialog.form.SlackFormElementTypes;
+import com.hubspot.slack.client.models.dialog.form.elements.helper.SlackDialogElementNormalizer;
 
 @Immutable
 @HubSpotStyle
@@ -23,19 +26,24 @@ public abstract class AbstractSlackFormTextareaElement extends AbstractSlackDial
   }
 
   @Check
-  public void validate() {
-    super.validateBaseTextElementProps();
+  public AbstractSlackFormTextareaElement validate() {
+    AbstractSlackFormTextareaElement normalized = SlackDialogElementNormalizer.normalize(this);
+    super.validateBaseTextElementProps(normalized);
 
-    if (getMaxLength() > 3000) {
-      throw new IllegalStateException("Form text area cannot have max length > 3000 chars, got " + getMaxLength());
+    int normalizedMaxLength = normalized.getMaxLength();
+    if (normalizedMaxLength > SlackDialogFormElementLengthLimits.MAX_TEXT_ELEMENT_VALUE_LENGTH.getLimit()) {
+      throw new IllegalStateException("Form text area cannot have max length > 3000 chars, got " + normalizedMaxLength);
     }
 
-    if (getMinLength() > 3000) {
-      throw new IllegalStateException("Form text area cannot have min length > 3000 chars, got " + getMinLength());
+    int normalizedMinLength = normalized.getMinLength();
+    if (normalizedMinLength > SlackDialogFormElementLengthLimits.MAX_TEXT_ELEMENT_VALUE_LENGTH.getLimit()) {
+      throw new IllegalStateException("Form text area cannot have min length > 3000 chars, got " + normalizedMinLength);
     }
 
-    if (getValue().isPresent() && getValue().get().length() > 3000) {
-      throw new IllegalStateException("Value cannot exceed 3000 chars, got '" + getValue().get() + "'");
+    Optional<String> value = normalized.getValue();
+    if (value.isPresent() && value.get().length() > 3000) {
+      throw new IllegalStateException("Value cannot exceed 3000 chars, got '" + value.get() + "'");
     }
+    return normalized;
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextareaElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextareaElement.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.dialog.form.SlackFormElementTypes;
-import com.hubspot.slack.client.models.dialog.form.elements.helper.SlackDialogElementNormalizer;
+import com.hubspot.slack.client.models.dialog.form.elements.helpers.SlackDialogElementNormalizer;
 
 @Immutable
 @HubSpotStyle
@@ -31,18 +31,22 @@ public abstract class AbstractSlackFormTextareaElement extends AbstractSlackDial
     super.validateBaseTextElementProps(normalized);
 
     int normalizedMaxLength = normalized.getMaxLength();
-    if (normalizedMaxLength > SlackDialogFormElementLengthLimits.MAX_TEXT_ELEMENT_VALUE_LENGTH.getLimit()) {
-      throw new IllegalStateException("Form text area cannot have max length > 3000 chars, got " + normalizedMaxLength);
+    int maxTextareaElementValueLengthLimit = SlackDialogFormElementLengthLimits.MAX_TEXT_AREA_ELEMENT_VALUE_LENGTH.getLimit();
+    if (normalizedMaxLength > maxTextareaElementValueLengthLimit) {
+      String errorMessage = String.format("Form text area cannot have max length > %s chars, got %s", maxTextareaElementValueLengthLimit, normalizedMaxLength);
+      throw new IllegalStateException(errorMessage);
     }
 
     int normalizedMinLength = normalized.getMinLength();
-    if (normalizedMinLength > SlackDialogFormElementLengthLimits.MAX_TEXT_ELEMENT_VALUE_LENGTH.getLimit()) {
-      throw new IllegalStateException("Form text area cannot have min length > 3000 chars, got " + normalizedMinLength);
+    if (normalizedMinLength > maxTextareaElementValueLengthLimit) {
+      String errorMessage = String.format("Form text area cannot have min length > %s chars, got %s", maxTextareaElementValueLengthLimit, normalizedMinLength);
+      throw new IllegalStateException(errorMessage);
     }
 
     Optional<String> value = normalized.getValue();
-    if (value.isPresent() && value.get().length() > 3000) {
-      throw new IllegalStateException("Value cannot exceed 3000 chars, got '" + value.get() + "'");
+    if (value.isPresent() && value.get().length() > maxTextareaElementValueLengthLimit) {
+      String errorMessage = String.format("Value cannot exceed %s chars, got %s", maxTextareaElementValueLengthLimit, value.get());
+      throw new IllegalStateException(errorMessage);
     }
     return normalized;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/HasLabel.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/HasLabel.java
@@ -1,0 +1,5 @@
+package com.hubspot.slack.client.models.dialog.form.elements;
+
+public interface HasLabel {
+  String getLabel();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/HasOptions.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/HasOptions.java
@@ -1,0 +1,7 @@
+package com.hubspot.slack.client.models.dialog.form.elements;
+
+import java.util.List;
+
+public interface HasOptions {
+  List<SlackFormOption> getOptions();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackDialogFormElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackDialogFormElement.java
@@ -17,19 +17,28 @@ public abstract class SlackDialogFormElement implements HasLabel {
 
   protected void validateBaseElementProperties(SlackDialogFormElement normalized) {
     String normalizedLabel = normalized.getLabel();
-    if (normalizedLabel.length() > SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH.getLimit()) {
-      throw new IllegalStateException("Label cannot exceed 24 chars, got " + normalizedLabel);
+    int maxLabelLength = SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH.getLimit();
+    if (normalizedLabel.length() > maxLabelLength) {
+      String errorMessage = String.format("Label cannot exceed %s chars, got %s", maxLabelLength, normalizedLabel);
+      throw new IllegalStateException(errorMessage);
     }
 
     String normalizedName = normalized.getName();
-    if (normalizedName.length() > SlackDialogFormElementLengthLimits.MAX_NAME_LENGTH.getLimit()) {
-      throw new IllegalStateException("Name cannot exceed 300 chars, got " + normalizedName);
+    int maxNameLength = SlackDialogFormElementLengthLimits.MAX_NAME_LENGTH.getLimit();
+    if (normalizedName.length() > maxNameLength) {
+      String errorMessage = String.format("Name cannot exceed %s chars, got %s", maxNameLength, normalizedName);
+      throw new IllegalStateException(errorMessage);
     }
 
     Optional<String> normalizedPlaceholder = normalized.getPlaceholder();
-    if (normalizedPlaceholder.isPresent() && normalizedPlaceholder.get().length() > SlackDialogFormElementLengthLimits.MAX_PLACEHOLDER_LENGTH
-        .getLimit()) {
-      throw new IllegalStateException("Placeholder length cannot exceed 150 chars, got " + normalizedPlaceholder.get());
+    int maxPlaceholderLength = SlackDialogFormElementLengthLimits.MAX_PLACEHOLDER_LENGTH.getLimit();
+    if (normalizedPlaceholder.isPresent() && normalizedPlaceholder.get().length() > maxPlaceholderLength) {
+      String errorMessage = String.format(
+          "Placeholder cannot exceed %s chars, got %s",
+          maxPlaceholderLength,
+          normalizedPlaceholder.get()
+      );
+      throw new IllegalStateException(errorMessage);
     }
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackDialogFormElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackDialogFormElement.java
@@ -5,26 +5,31 @@ import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hubspot.slack.client.models.dialog.form.SlackFormElementTypes;
 
-public abstract class SlackDialogFormElement {
+public abstract class SlackDialogFormElement implements HasLabel {
   public abstract SlackFormElementTypes getType();
+
   public abstract String getName();
-  public abstract String getLabel();
+
   public abstract Optional<String> getPlaceholder();
 
   @JsonProperty("optional")
   public abstract Optional<Boolean> isOptional();
 
-  protected void validateBaseElementProperties() {
-    if (getLabel().length() > 24) {
-      throw new IllegalStateException("Label cannot exceed 24 chars, got " + getLabel());
+  protected void validateBaseElementProperties(SlackDialogFormElement normalized) {
+    String normalizedLabel = normalized.getLabel();
+    if (normalizedLabel.length() > SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH.getLimit()) {
+      throw new IllegalStateException("Label cannot exceed 24 chars, got " + normalizedLabel);
     }
 
-    if (getName().length() > 300) {
-      throw new IllegalStateException("Name cannot exceed 300 chars, got " + getName());
+    String normalizedName = normalized.getName();
+    if (normalizedName.length() > SlackDialogFormElementLengthLimits.MAX_NAME_LENGTH.getLimit()) {
+      throw new IllegalStateException("Name cannot exceed 300 chars, got " + normalizedName);
     }
 
-    if (getPlaceholder().isPresent() && getPlaceholder().get().length() > 150) {
-      throw new IllegalStateException("Placeholder length cannot exceed 150 chars, got " + getPlaceholder().get());
+    Optional<String> normalizedPlaceholder = normalized.getPlaceholder();
+    if (normalizedPlaceholder.isPresent() && normalizedPlaceholder.get().length() > SlackDialogFormElementLengthLimits.MAX_PLACEHOLDER_LENGTH
+        .getLimit()) {
+      throw new IllegalStateException("Placeholder length cannot exceed 150 chars, got " + normalizedPlaceholder.get());
     }
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackDialogFormElementLengthLimits.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackDialogFormElementLengthLimits.java
@@ -1,0 +1,24 @@
+package com.hubspot.slack.client.models.dialog.form.elements;
+
+public enum SlackDialogFormElementLengthLimits {
+  MAX_LABEL_LENGTH(24),
+  MAX_NAME_LENGTH(300),
+   MAX_PLACEHOLDER_LENGTH(150),
+   MAX_HINT_LENGTH(150),
+   MAX_TEXT_ELEMENT_VALUE_LENGTH(150),
+  MAX_TEXT_AREA_ELEMENT_VALUE_LENGTH(3000),
+   MAX_OPTION_LABEL_LENGTH(75),
+   MAX_OPTION_VALUE_LENGTH(75),
+   MAX_OPTIONS_NUMBER(100),
+   MAX_OPTION_GROUPS_NUMBER(100);
+
+  private final int limit;
+
+  SlackDialogFormElementLengthLimits(int limit) {
+    this.limit = limit;
+  }
+
+  public int getLimit() {
+    return limit;
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionGroupIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionGroupIF.java
@@ -9,29 +9,32 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Strings;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.dialog.form.elements.helper.SlackDialogElementNormalizer;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface SlackFormOptionGroupIF {
-  String getLabel();
+public interface SlackFormOptionGroupIF extends HasLabel{
   List<SlackFormOption> getOptions();
 
   @Check
-  default void validate() {
-    String label = getLabel();
-    int numOptionGroups = getOptions().size();
+  default SlackFormOptionGroupIF validate() {
+    SlackFormOptionGroupIF normalized = SlackDialogElementNormalizer.normalize(this);
+    String label = normalized.getLabel();
+    int numOptions = normalized.getOptions().size();
 
     if (Strings.isNullOrEmpty(label)) {
       throw new IllegalStateException("Must provide a label");
     }
 
-    if (label.length() > 75) {
+    if (label.length() > SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH.getLimit()) {
       throw new IllegalStateException("Label cannot exceed 75 chars - '" + label + "'");
     }
 
-    if (numOptionGroups > 100) {
-      throw new IllegalStateException("Cannot have more than 100 option groups. Has " + numOptionGroups);
+    if (numOptions > SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER.getLimit()) {
+      throw new IllegalStateException("Cannot have more than 100 option groups. Has " + numOptions);
     }
+
+    return normalized;
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionGroupIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionGroupIF.java
@@ -1,7 +1,5 @@
 package com.hubspot.slack.client.models.dialog.form.elements;
 
-import java.util.List;
-
 import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 
@@ -9,14 +7,12 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Strings;
 import com.hubspot.immutables.style.HubSpotStyle;
-import com.hubspot.slack.client.models.dialog.form.elements.helper.SlackDialogElementNormalizer;
+import com.hubspot.slack.client.models.dialog.form.elements.helpers.SlackDialogElementNormalizer;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface SlackFormOptionGroupIF extends HasLabel{
-  List<SlackFormOption> getOptions();
-
+public interface SlackFormOptionGroupIF extends HasLabel, HasOptions {
   @Check
   default SlackFormOptionGroupIF validate() {
     SlackFormOptionGroupIF normalized = SlackDialogElementNormalizer.normalize(this);
@@ -27,12 +23,16 @@ public interface SlackFormOptionGroupIF extends HasLabel{
       throw new IllegalStateException("Must provide a label");
     }
 
-    if (label.length() > SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH.getLimit()) {
-      throw new IllegalStateException("Label cannot exceed 75 chars - '" + label + "'");
+    int maxOptionLabelLength = SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH.getLimit();
+    if (label.length() > maxOptionLabelLength) {
+      String errorMessage = String.format("Label cannot exceed %s chars - '%s'", maxOptionLabelLength, label);
+      throw new IllegalStateException(errorMessage);
     }
 
-    if (numOptions > SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER.getLimit()) {
-      throw new IllegalStateException("Cannot have more than 100 option groups. Has " + numOptions);
+    int maxOptionsNumber = SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER.getLimit();
+    if (numOptions > maxOptionsNumber) {
+      String errorMessage = String.format("Cannot have more than %s option groups. Has %s", maxOptionsNumber, numOptions);
+      throw new IllegalStateException(errorMessage);
     }
 
     return normalized;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionIF.java
@@ -7,22 +7,23 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Strings;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.dialog.form.elements.helper.SlackDialogElementNormalizer;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface SlackFormOptionIF {
-  String getLabel();
+public interface SlackFormOptionIF extends HasLabel{
   String getValue();
 
   @Check
-  default void validate() {
+  default SlackFormOptionIF validate() {
+    SlackFormOptionIF normalized = SlackDialogElementNormalizer.normalize(this);
     if (Strings.isNullOrEmpty(getLabel())) {
       throw new IllegalStateException("Must provide a label");
     }
 
-    String label = getLabel();
-    if (label.length() > 75) {
+    String label = normalized.getLabel();
+    if (label.length() > SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH.getLimit()) {
       throw new IllegalStateException("Label cannot exceed 75 chars - '" + label + "'");
     }
 
@@ -30,9 +31,10 @@ public interface SlackFormOptionIF {
       throw new IllegalStateException("Must provide a value");
     }
 
-    String value = getValue();
-    if (value.length() > 75) {
+    String value = normalized.getValue();
+    if (value.length() > SlackDialogFormElementLengthLimits.MAX_OPTION_VALUE_LENGTH.getLimit()) {
       throw new IllegalStateException("Value cannot exceed 75 chars - '" + value + "'");
     }
+    return normalized;
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionIF.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Strings;
 import com.hubspot.immutables.style.HubSpotStyle;
-import com.hubspot.slack.client.models.dialog.form.elements.helper.SlackDialogElementNormalizer;
+import com.hubspot.slack.client.models.dialog.form.elements.helpers.SlackDialogElementNormalizer;
 
 @Immutable
 @HubSpotStyle
@@ -23,8 +23,10 @@ public interface SlackFormOptionIF extends HasLabel{
     }
 
     String label = normalized.getLabel();
-    if (label.length() > SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH.getLimit()) {
-      throw new IllegalStateException("Label cannot exceed 75 chars - '" + label + "'");
+    int maxOptionLabelLength = SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH.getLimit();
+    if (label.length() > maxOptionLabelLength) {
+      String errorMessage = String.format("Label cannot exceed %s chars - '%s'", maxOptionLabelLength, label);
+      throw new IllegalStateException(errorMessage);
     }
 
     if (Strings.isNullOrEmpty(getValue())) {
@@ -32,8 +34,10 @@ public interface SlackFormOptionIF extends HasLabel{
     }
 
     String value = normalized.getValue();
-    if (value.length() > SlackDialogFormElementLengthLimits.MAX_OPTION_VALUE_LENGTH.getLimit()) {
-      throw new IllegalStateException("Value cannot exceed 75 chars - '" + value + "'");
+    int maxOptionValueLength = SlackDialogFormElementLengthLimits.MAX_OPTION_VALUE_LENGTH.getLimit();
+    if (value.length() > maxOptionValueLength) {
+      String errorMessage = String.format("Value cannot exceed %s chars - '%s'", maxOptionValueLength, value);
+      throw new IllegalStateException(errorMessage);
     }
     return normalized;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/helper/SlackDialogElementNormalizer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/helper/SlackDialogElementNormalizer.java
@@ -1,0 +1,195 @@
+package com.hubspot.slack.client.models.dialog.form.elements.helper;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.google.common.collect.Iterables;
+import com.hubspot.slack.client.models.dialog.form.elements.AbstractSlackDialogFormTextElement;
+import com.hubspot.slack.client.models.dialog.form.elements.AbstractSlackFormSelectElement;
+import com.hubspot.slack.client.models.dialog.form.elements.AbstractSlackFormTextElement;
+import com.hubspot.slack.client.models.dialog.form.elements.AbstractSlackFormTextareaElement;
+import com.hubspot.slack.client.models.dialog.form.elements.HasLabel;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackDialogFormElement;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackDialogFormElementLengthLimits;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackFormOption;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackFormOptionGroup;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackFormOptionGroupIF;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackFormOptionIF;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackFormSelectElement;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackFormTextElement;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackFormTextareaElement;
+
+public class SlackDialogElementNormalizer {
+  private SlackDialogElementNormalizer() {
+  }
+
+  public static AbstractSlackFormTextElement normalize(AbstractSlackFormTextElement element) {
+    if (shouldNormalizePlaceholder(element, SlackDialogFormElementLengthLimits.MAX_PLACEHOLDER_LENGTH)
+        || shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH)
+        || shouldNormalizeName(element)
+        || shouldNormalize(element.getHint(), SlackDialogFormElementLengthLimits.MAX_HINT_LENGTH)
+        || shouldNormalize(element.getValue(), SlackDialogFormElementLengthLimits.MAX_TEXT_ELEMENT_VALUE_LENGTH)) {
+      return SlackFormTextElement.copyOf(element)
+          .withPlaceholder(normalizePlaceholder(element))
+          .withLabel(normalizeLabel(element))
+          .withName(normalizeName(element))
+          .withHint(normalizeHint(element))
+          .withValue(normalizeTextElementValue(element));
+    }
+    return element;
+  }
+
+  public static AbstractSlackFormTextareaElement normalize(AbstractSlackFormTextareaElement element) {
+    if (shouldNormalizePlaceholder(element, SlackDialogFormElementLengthLimits.MAX_PLACEHOLDER_LENGTH)
+        || shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH)
+        || shouldNormalizeName(element)
+        || shouldNormalize(element.getHint(), SlackDialogFormElementLengthLimits.MAX_HINT_LENGTH)
+        || shouldNormalize(element.getValue(), SlackDialogFormElementLengthLimits.MAX_TEXT_AREA_ELEMENT_VALUE_LENGTH)) {
+      return SlackFormTextareaElement.copyOf(element)
+          .withPlaceholder(normalizePlaceholder(element))
+          .withLabel(normalizeLabel(element))
+          .withName(normalizeName(element))
+          .withHint(normalizeHint(element))
+          .withValue(normalizeTextAreaElementValue(element));
+    }
+    return element;
+  }
+
+  public static AbstractSlackFormSelectElement normalize(AbstractSlackFormSelectElement element) {
+    if (shouldNormalizePlaceholder(element, SlackDialogFormElementLengthLimits.MAX_PLACEHOLDER_LENGTH)
+        || shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH)
+        || shouldNormalizeName(element)
+        || shouldNormalize(element.getOptionGroups(), SlackDialogFormElementLengthLimits.MAX_OPTION_GROUPS_NUMBER)
+        || shouldNormalize(element.getOptions(), SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER)) {
+      return SlackFormSelectElement.copyOf(element)
+          .withPlaceholder(normalizePlaceholder(element))
+          .withLabel(normalizeLabel(element))
+          .withName(normalizeName(element))
+          .withOptionGroups(normalizeOptionGroups(element))
+          .withOptions(normalizeOptions(element));
+    }
+    return element;
+  }
+
+  public static SlackFormOptionIF normalize(SlackFormOptionIF element) {
+    if (shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH)
+        || shouldNormalize(element.getValue(), SlackDialogFormElementLengthLimits.MAX_OPTION_VALUE_LENGTH)) {
+      return SlackFormOption.copyOf(element)
+          .withLabel(normalizeLabel(element))
+          .withValue(normalizeValue(element));
+    }
+    return element;
+  }
+
+  public static SlackFormOptionGroupIF normalize(SlackFormOptionGroupIF element) {
+    if (shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH)
+        || shouldNormalize(element.getOptions(), SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER)) {
+      return SlackFormOptionGroup.builder()
+          .from(element)
+          .setLabel(normalizeLabel(element))
+          .setOptions(normalizeOptions(element))
+          .build();
+    }
+    return element;
+  }
+
+  private static boolean shouldNormalize(List listOfFormElements, SlackDialogFormElementLengthLimits maxListSize) {
+    return listOfFormElements.size() > maxListSize.getLimit();
+  }
+
+  private static boolean shouldNormalizeName(SlackDialogFormElement element) {
+    return shouldNormalize(element.getName(), SlackDialogFormElementLengthLimits.MAX_NAME_LENGTH);
+  }
+
+  private static boolean shouldNormalizePlaceholder(SlackDialogFormElement element,
+                                                    SlackDialogFormElementLengthLimits maxLengthLimit) {
+    return shouldNormalize(element.getPlaceholder(), maxLengthLimit);
+  }
+
+  private static boolean shouldNormalizeLabel(HasLabel element, SlackDialogFormElementLengthLimits maxLabelLength) {
+    return shouldNormalize(element.getLabel(), maxLabelLength);
+  }
+
+  private static boolean shouldNormalize(Optional<String> stringOptional,
+                                         SlackDialogFormElementLengthLimits maxPlaceholderLength) {
+    return stringOptional.isPresent() && shouldNormalize(stringOptional.get(), maxPlaceholderLength);
+  }
+
+  private static boolean shouldNormalize(String string,
+                                         SlackDialogFormElementLengthLimits maxPlaceholderLength) {
+    return string.length() > maxPlaceholderLength.getLimit();
+  }
+
+  private static String normalizeLabel(SlackFormOptionIF option) {
+    return normalizeIfLongerThan(option.getLabel(), SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH.getLimit());
+  }
+
+  private static String normalizeValue(SlackFormOptionIF option) {
+    return normalizeIfLongerThan(option.getValue(), SlackDialogFormElementLengthLimits.MAX_OPTION_VALUE_LENGTH.getLimit());
+  }
+
+  private static String normalizeLabel(SlackFormOptionGroupIF optionGroup) {
+    return normalizeIfLongerThan(optionGroup.getLabel(), SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH.getLimit());
+  }
+
+  private static Iterable<SlackFormOptionGroup> normalizeOptionGroups(AbstractSlackFormSelectElement element) {
+    return Iterables.limit(element.getOptionGroups(), SlackDialogFormElementLengthLimits.MAX_OPTION_GROUPS_NUMBER.getLimit());
+  }
+
+  private static Iterable<SlackFormOption> normalizeOptions(AbstractSlackFormSelectElement element) {
+    return Iterables.limit(element.getOptions(), SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER.getLimit());
+  }
+
+  private static Iterable<SlackFormOption> normalizeOptions(SlackFormOptionGroupIF element) {
+    return Iterables.limit(element.getOptions(), SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER.getLimit());
+  }
+
+  private static String normalizeLabel(SlackDialogFormElement element) {
+    return normalizeIfLongerThan(element.getLabel(), SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH.getLimit());
+  }
+
+  private static String normalizeName(SlackDialogFormElement element) {
+    return normalizeIfLongerThan(element.getName(), SlackDialogFormElementLengthLimits.MAX_NAME_LENGTH.getLimit());
+  }
+
+  private static Optional<String> normalizePlaceholder(SlackDialogFormElement element) {
+    return element.getPlaceholder()
+        .map(placeholder ->
+            normalizeIfLongerThan(
+                placeholder,
+                SlackDialogFormElementLengthLimits.MAX_PLACEHOLDER_LENGTH.getLimit()
+            ));
+  }
+
+  private static Optional<String> normalizeHint(AbstractSlackDialogFormTextElement element) {
+    return element.getHint()
+        .map(hint -> normalizeIfLongerThan(hint, SlackDialogFormElementLengthLimits.MAX_HINT_LENGTH.getLimit()));
+  }
+
+  private static Optional<String> normalizeTextElementValue(AbstractSlackFormTextElement element) {
+    return element.getValue()
+        .map(value ->
+            normalizeIfLongerThan(
+                value,
+                SlackDialogFormElementLengthLimits.MAX_TEXT_ELEMENT_VALUE_LENGTH.getLimit()
+            ));
+  }
+
+  private static Optional<String> normalizeTextAreaElementValue(AbstractSlackFormTextareaElement element) {
+    return element.getValue()
+        .map(value ->
+            normalizeIfLongerThan(
+                value,
+                SlackDialogFormElementLengthLimits.MAX_TEXT_AREA_ELEMENT_VALUE_LENGTH.getLimit()
+            ));
+  }
+
+  private static String normalizeIfLongerThan(String label, int maxLength) {
+    if (label.length() > maxLength) {
+      String ellipsis = "...";
+      int endIndex = (maxLength - ellipsis.length()) - 1;
+      return label.substring(0, endIndex) + ellipsis;
+    }
+    return label;
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/helper/SlackDialogElementNormalizer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/helper/SlackDialogElementNormalizer.java
@@ -26,15 +26,11 @@ public class SlackDialogElementNormalizer {
   public static AbstractSlackFormTextElement normalize(AbstractSlackFormTextElement element) {
     if (shouldNormalizePlaceholder(element, SlackDialogFormElementLengthLimits.MAX_PLACEHOLDER_LENGTH)
         || shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH)
-        || shouldNormalizeName(element)
-        || shouldNormalize(element.getHint(), SlackDialogFormElementLengthLimits.MAX_HINT_LENGTH)
-        || shouldNormalize(element.getValue(), SlackDialogFormElementLengthLimits.MAX_TEXT_ELEMENT_VALUE_LENGTH)) {
+        || shouldNormalize(element.getHint(), SlackDialogFormElementLengthLimits.MAX_HINT_LENGTH)) {
       return SlackFormTextElement.copyOf(element)
           .withPlaceholder(normalizePlaceholder(element))
           .withLabel(normalizeLabel(element))
-          .withName(normalizeName(element))
-          .withHint(normalizeHint(element))
-          .withValue(normalizeTextElementValue(element));
+          .withHint(normalizeHint(element));
     }
     return element;
   }
@@ -42,15 +38,11 @@ public class SlackDialogElementNormalizer {
   public static AbstractSlackFormTextareaElement normalize(AbstractSlackFormTextareaElement element) {
     if (shouldNormalizePlaceholder(element, SlackDialogFormElementLengthLimits.MAX_PLACEHOLDER_LENGTH)
         || shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH)
-        || shouldNormalizeName(element)
-        || shouldNormalize(element.getHint(), SlackDialogFormElementLengthLimits.MAX_HINT_LENGTH)
-        || shouldNormalize(element.getValue(), SlackDialogFormElementLengthLimits.MAX_TEXT_AREA_ELEMENT_VALUE_LENGTH)) {
+        || shouldNormalize(element.getHint(), SlackDialogFormElementLengthLimits.MAX_HINT_LENGTH)) {
       return SlackFormTextareaElement.copyOf(element)
           .withPlaceholder(normalizePlaceholder(element))
           .withLabel(normalizeLabel(element))
-          .withName(normalizeName(element))
-          .withHint(normalizeHint(element))
-          .withValue(normalizeTextAreaElementValue(element));
+          .withHint(normalizeHint(element));
     }
     return element;
   }
@@ -58,13 +50,11 @@ public class SlackDialogElementNormalizer {
   public static AbstractSlackFormSelectElement normalize(AbstractSlackFormSelectElement element) {
     if (shouldNormalizePlaceholder(element, SlackDialogFormElementLengthLimits.MAX_PLACEHOLDER_LENGTH)
         || shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH)
-        || shouldNormalizeName(element)
         || shouldNormalize(element.getOptionGroups(), SlackDialogFormElementLengthLimits.MAX_OPTION_GROUPS_NUMBER)
         || shouldNormalize(element.getOptions(), SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER)) {
       return SlackFormSelectElement.copyOf(element)
           .withPlaceholder(normalizePlaceholder(element))
           .withLabel(normalizeLabel(element))
-          .withName(normalizeName(element))
           .withOptionGroups(normalizeOptionGroups(element))
           .withOptions(normalizeOptions(element));
     }
@@ -72,11 +62,8 @@ public class SlackDialogElementNormalizer {
   }
 
   public static SlackFormOptionIF normalize(SlackFormOptionIF element) {
-    if (shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH)
-        || shouldNormalize(element.getValue(), SlackDialogFormElementLengthLimits.MAX_OPTION_VALUE_LENGTH)) {
-      return SlackFormOption.copyOf(element)
-          .withLabel(normalizeLabel(element))
-          .withValue(normalizeValue(element));
+    if (shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH)) {
+      return SlackFormOption.copyOf(element).withLabel(normalizeLabel(element));
     }
     return element;
   }
@@ -95,10 +82,6 @@ public class SlackDialogElementNormalizer {
 
   private static boolean shouldNormalize(List listOfFormElements, SlackDialogFormElementLengthLimits maxListSize) {
     return listOfFormElements.size() > maxListSize.getLimit();
-  }
-
-  private static boolean shouldNormalizeName(SlackDialogFormElement element) {
-    return shouldNormalize(element.getName(), SlackDialogFormElementLengthLimits.MAX_NAME_LENGTH);
   }
 
   private static boolean shouldNormalizePlaceholder(SlackDialogFormElement element,
@@ -124,10 +107,6 @@ public class SlackDialogElementNormalizer {
     return normalizeIfLongerThan(option.getLabel(), SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH.getLimit());
   }
 
-  private static String normalizeValue(SlackFormOptionIF option) {
-    return normalizeIfLongerThan(option.getValue(), SlackDialogFormElementLengthLimits.MAX_OPTION_VALUE_LENGTH.getLimit());
-  }
-
   private static String normalizeLabel(SlackFormOptionGroupIF optionGroup) {
     return normalizeIfLongerThan(optionGroup.getLabel(), SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH.getLimit());
   }
@@ -148,10 +127,6 @@ public class SlackDialogElementNormalizer {
     return normalizeIfLongerThan(element.getLabel(), SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH.getLimit());
   }
 
-  private static String normalizeName(SlackDialogFormElement element) {
-    return normalizeIfLongerThan(element.getName(), SlackDialogFormElementLengthLimits.MAX_NAME_LENGTH.getLimit());
-  }
-
   private static Optional<String> normalizePlaceholder(SlackDialogFormElement element) {
     return element.getPlaceholder()
         .map(placeholder ->
@@ -164,24 +139,6 @@ public class SlackDialogElementNormalizer {
   private static Optional<String> normalizeHint(AbstractSlackDialogFormTextElement element) {
     return element.getHint()
         .map(hint -> normalizeIfLongerThan(hint, SlackDialogFormElementLengthLimits.MAX_HINT_LENGTH.getLimit()));
-  }
-
-  private static Optional<String> normalizeTextElementValue(AbstractSlackFormTextElement element) {
-    return element.getValue()
-        .map(value ->
-            normalizeIfLongerThan(
-                value,
-                SlackDialogFormElementLengthLimits.MAX_TEXT_ELEMENT_VALUE_LENGTH.getLimit()
-            ));
-  }
-
-  private static Optional<String> normalizeTextAreaElementValue(AbstractSlackFormTextareaElement element) {
-    return element.getValue()
-        .map(value ->
-            normalizeIfLongerThan(
-                value,
-                SlackDialogFormElementLengthLimits.MAX_TEXT_AREA_ELEMENT_VALUE_LENGTH.getLimit()
-            ));
   }
 
   private static String normalizeIfLongerThan(String label, int maxLength) {

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/helpers/SlackDialogElementNormalizer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/helpers/SlackDialogElementNormalizer.java
@@ -1,4 +1,4 @@
-package com.hubspot.slack.client.models.dialog.form.elements.helper;
+package com.hubspot.slack.client.models.dialog.form.elements.helpers;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,6 +9,7 @@ import com.hubspot.slack.client.models.dialog.form.elements.AbstractSlackFormSel
 import com.hubspot.slack.client.models.dialog.form.elements.AbstractSlackFormTextElement;
 import com.hubspot.slack.client.models.dialog.form.elements.AbstractSlackFormTextareaElement;
 import com.hubspot.slack.client.models.dialog.form.elements.HasLabel;
+import com.hubspot.slack.client.models.dialog.form.elements.HasOptions;
 import com.hubspot.slack.client.models.dialog.form.elements.SlackDialogFormElement;
 import com.hubspot.slack.client.models.dialog.form.elements.SlackDialogFormElementLengthLimits;
 import com.hubspot.slack.client.models.dialog.form.elements.SlackFormOption;
@@ -24,7 +25,7 @@ public class SlackDialogElementNormalizer {
   }
 
   public static AbstractSlackFormTextElement normalize(AbstractSlackFormTextElement element) {
-    if (shouldNormalizePlaceholder(element, SlackDialogFormElementLengthLimits.MAX_PLACEHOLDER_LENGTH)
+    if (shouldNormalizePlaceholder(element)
         || shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH)
         || shouldNormalize(element.getHint(), SlackDialogFormElementLengthLimits.MAX_HINT_LENGTH)) {
       return SlackFormTextElement.copyOf(element)
@@ -36,7 +37,7 @@ public class SlackDialogElementNormalizer {
   }
 
   public static AbstractSlackFormTextareaElement normalize(AbstractSlackFormTextareaElement element) {
-    if (shouldNormalizePlaceholder(element, SlackDialogFormElementLengthLimits.MAX_PLACEHOLDER_LENGTH)
+    if (shouldNormalizePlaceholder(element)
         || shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH)
         || shouldNormalize(element.getHint(), SlackDialogFormElementLengthLimits.MAX_HINT_LENGTH)) {
       return SlackFormTextareaElement.copyOf(element)
@@ -48,10 +49,10 @@ public class SlackDialogElementNormalizer {
   }
 
   public static AbstractSlackFormSelectElement normalize(AbstractSlackFormSelectElement element) {
-    if (shouldNormalizePlaceholder(element, SlackDialogFormElementLengthLimits.MAX_PLACEHOLDER_LENGTH)
+    if (shouldNormalizePlaceholder(element)
         || shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH)
         || shouldNormalize(element.getOptionGroups(), SlackDialogFormElementLengthLimits.MAX_OPTION_GROUPS_NUMBER)
-        || shouldNormalize(element.getOptions(), SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER)) {
+        || shouldNormalizeOptions(element)) {
       return SlackFormSelectElement.copyOf(element)
           .withPlaceholder(normalizePlaceholder(element))
           .withLabel(normalizeLabel(element))
@@ -61,16 +62,9 @@ public class SlackDialogElementNormalizer {
     return element;
   }
 
-  public static SlackFormOptionIF normalize(SlackFormOptionIF element) {
-    if (shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH)) {
-      return SlackFormOption.copyOf(element).withLabel(normalizeLabel(element));
-    }
-    return element;
-  }
-
   public static SlackFormOptionGroupIF normalize(SlackFormOptionGroupIF element) {
     if (shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH)
-        || shouldNormalize(element.getOptions(), SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER)) {
+        || shouldNormalizeOptions(element)) {
       return SlackFormOptionGroup.builder()
           .from(element)
           .setLabel(normalizeLabel(element))
@@ -80,13 +74,23 @@ public class SlackDialogElementNormalizer {
     return element;
   }
 
+  private static boolean shouldNormalizeOptions(HasOptions element) {
+    return shouldNormalize(element.getOptions(), SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER);
+  }
+
+  public static SlackFormOptionIF normalize(SlackFormOptionIF element) {
+    if (shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH)) {
+      return SlackFormOption.copyOf(element).withLabel(normalizeLabel(element));
+    }
+    return element;
+  }
+
   private static boolean shouldNormalize(List listOfFormElements, SlackDialogFormElementLengthLimits maxListSize) {
     return listOfFormElements.size() > maxListSize.getLimit();
   }
 
-  private static boolean shouldNormalizePlaceholder(SlackDialogFormElement element,
-                                                    SlackDialogFormElementLengthLimits maxLengthLimit) {
-    return shouldNormalize(element.getPlaceholder(), maxLengthLimit);
+  private static boolean shouldNormalizePlaceholder(SlackDialogFormElement element) {
+    return shouldNormalize(element.getPlaceholder(), SlackDialogFormElementLengthLimits.MAX_PLACEHOLDER_LENGTH);
   }
 
   private static boolean shouldNormalizeLabel(HasLabel element, SlackDialogFormElementLengthLimits maxLabelLength) {

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackDialogFormElementTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackDialogFormElementTest.java
@@ -1,0 +1,45 @@
+package com.hubspot.slack.client.models.dialog.form.elements;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.junit.Test;
+
+import com.hubspot.slack.client.testutils.StringGenerator;
+
+public class SlackDialogFormElementTest {
+
+  @Test
+  public void itFailsToBuildDialogFormElementForMissingTooLongName() {
+    String tooLongName = StringGenerator.generateStringWithLength(301);
+    try {
+      SlackFormTextElement.builder().setLabel("ignored").setName(tooLongName).build();
+    } catch (IllegalStateException ise) {
+      assertThat(ise.getMessage()).contains("Name cannot exceed 300 chars, got " + tooLongName);
+      return;
+    }
+
+    fail("Didn't throw exception");
+  }
+
+  @Test
+  public void itNormalizesLongLabelToBuildFormSelectElement() {
+    SlackFormTextElement slackFormTextElement = SlackFormTextElement.builder()
+        .setLabel(StringGenerator.generateStringWithLength(25))
+        .setName("ignored")
+        .build();
+    String expectedLabel = StringGenerator.generateStringWithLengthAndEllipsis(20);
+    assertThat(slackFormTextElement.getLabel()).isEqualTo(expectedLabel);
+  }
+
+  @Test
+  public void itNormalizesLongPlaceholderToBuildFormSelectElement() {
+    SlackFormTextElement slackFormTextElement = SlackFormTextElement.builder()
+        .setLabel("ignored")
+        .setName("ignored")
+        .setPlaceholder(StringGenerator.generateStringWithLength(151))
+        .build();
+    String expectedLabel = StringGenerator.generateStringWithLengthAndEllipsis(146);
+    assertThat(slackFormTextElement.getPlaceholder()).hasValue(expectedLabel);
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionsTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionsTest.java
@@ -4,12 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
 
 import com.hubspot.slack.client.models.actions.SlackDataSource;
+import com.hubspot.slack.client.testutils.StringGenerator;
 
 public class SlackFormOptionsTest {
 
@@ -172,25 +172,29 @@ public class SlackFormOptionsTest {
   }
 
   @Test
-  public void itFailsToBuildFormSelectOptionGroupForLongLabel() {
-    try {
-      SlackFormOptionGroup.builder()
-          .setLabel(String.join("", Collections.nCopies(76, "a"))) // long label
-          .addOptions(SlackFormOption.builder()
-              .setLabel("label")
-              .setValue("value")
-              .build()
-          ).build();
-    } catch (IllegalStateException ise) {
-      assertThat(ise.getMessage()).contains("Label cannot exceed 75 chars");
-      return;
-    }
-
-    fail("Didn't throw exception");
+  public void itNormalizesLongLabelToBuildFormSelectOptionGroup() {
+    SlackFormOptionGroup optionGroup = SlackFormOptionGroup.builder()
+        .setLabel(StringGenerator.generateStringWithLength(76))
+        .addOptions(SlackFormOption.builder()
+            .setLabel("label")
+            .setValue("value")
+            .build()
+        ).build();
+    String expectedLabel = StringGenerator.generateStringWithLengthAndEllipsis(71);
+    assertThat(optionGroup.getLabel()).isEqualTo(expectedLabel);
   }
 
   @Test
-  public void itFailsToBuildFormSelectOptionGroupForInvalidNumberOfOptions() {
+  public void itNormalizesLongLabelToBuildFormSelectOption() {
+    SlackFormOption option = SlackFormOption.builder()
+        .setLabel(StringGenerator.generateStringWithLength(76))
+        .setValue("value-1").build();
+    String expectedLabel = StringGenerator.generateStringWithLengthAndEllipsis(71);
+    assertThat(option.getLabel()).isEqualTo(expectedLabel);
+  }
+
+  @Test
+  public void itNormalizesOptionsListToBuildFormSelectOptionGroup() {
     List<SlackFormOption> options = new ArrayList<>();
 
     for (int i = 0; i < 101; i++) {
@@ -200,16 +204,10 @@ public class SlackFormOptionsTest {
           .build());
     }
 
-    try {
-      SlackFormOptionGroup.builder()
-          .setLabel("label")
-          .setOptions(options)
-          .build();
-    } catch (IllegalStateException ise) {
-      assertThat(ise.getMessage()).contains("Cannot have more than 100 option groups");
-      return;
-    }
-
-    fail("Didn't throw exception");
+    SlackFormOptionGroup optionGroup = SlackFormOptionGroup.builder()
+        .setLabel("label")
+        .setOptions(options)
+        .build();
+    assertThat(optionGroup.getOptions()).hasSize(100);
   }
 }

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormTextElementTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormTextElementTest.java
@@ -1,0 +1,36 @@
+package com.hubspot.slack.client.models.dialog.form.elements;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.junit.Test;
+
+import com.hubspot.slack.client.testutils.StringGenerator;
+
+public class SlackFormTextElementTest{
+
+  @Test
+  public void itNormalizesLongHintToBuildFormSelectElement() {
+    SlackFormTextElement optionGroup = SlackFormTextElement.builder()
+        .setLabel("ignored")
+        .setName("ignored")
+        .setHint(StringGenerator.generateStringWithLength(151))
+        .build();
+    String expectedLabel = StringGenerator.generateStringWithLengthAndEllipsis(146);
+    assertThat(optionGroup.getHint()).hasValue(expectedLabel);
+  }
+
+  @Test
+  public void itFailsToBuildDialogFormElementForMissingTooLongValue() {
+    String tooLongValue = StringGenerator.generateStringWithLength(151);
+    try {
+      SlackFormTextElement.builder().setLabel("ignored").setName("ignored").setValue(tooLongValue).build();
+    } catch (IllegalStateException ise) {
+      String errorMessage = String.format("Value cannot exceed 150 chars, got '%s'", tooLongValue);
+      assertThat(ise.getMessage()).contains(errorMessage);
+      return;
+    }
+
+    fail("Didn't throw exception");
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormTextElementTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormTextElementTest.java
@@ -26,7 +26,7 @@ public class SlackFormTextElementTest{
     try {
       SlackFormTextElement.builder().setLabel("ignored").setName("ignored").setValue(tooLongValue).build();
     } catch (IllegalStateException ise) {
-      String errorMessage = String.format("Value cannot exceed 150 chars, got '%s'", tooLongValue);
+      String errorMessage = String.format("Value cannot exceed 150 chars, got %s", tooLongValue);
       assertThat(ise.getMessage()).contains(errorMessage);
       return;
     }

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormTextareaElementTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormTextareaElementTest.java
@@ -1,0 +1,36 @@
+package com.hubspot.slack.client.models.dialog.form.elements;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.junit.Test;
+
+import com.hubspot.slack.client.testutils.StringGenerator;
+
+public class SlackFormTextareaElementTest {
+
+  @Test
+  public void itNormalizesLongHintToBuildFormSelectElement() {
+    SlackFormTextareaElement textareaElement = SlackFormTextareaElement.builder()
+        .setLabel("ignored")
+        .setName("ignored")
+        .setHint(StringGenerator.generateStringWithLength(151))
+        .build();
+    String expectedLabel = StringGenerator.generateStringWithLengthAndEllipsis(146);
+    assertThat(textareaElement.getHint()).hasValue(expectedLabel);
+  }
+
+  @Test
+  public void itFailsToBuildDialogFormElementForMissingTooLongValue() {
+    String tooLongValue = StringGenerator.generateStringWithLength(3001);
+    try {
+      SlackFormTextareaElement.builder().setLabel("ignored").setName("ignored").setValue(tooLongValue).build();
+    } catch (IllegalStateException ise) {
+      String errorMessage = String.format("Value cannot exceed 3000 chars, got '%s'", tooLongValue);
+      assertThat(ise.getMessage()).contains(errorMessage);
+      return;
+    }
+
+    fail("Didn't throw exception");
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormTextareaElementTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormTextareaElementTest.java
@@ -26,7 +26,7 @@ public class SlackFormTextareaElementTest {
     try {
       SlackFormTextareaElement.builder().setLabel("ignored").setName("ignored").setValue(tooLongValue).build();
     } catch (IllegalStateException ise) {
-      String errorMessage = String.format("Value cannot exceed 3000 chars, got '%s'", tooLongValue);
+      String errorMessage = String.format("Value cannot exceed 3000 chars, got %s", tooLongValue);
       assertThat(ise.getMessage()).contains(errorMessage);
       return;
     }

--- a/slack-base/src/test/java/com/hubspot/slack/client/testutils/StringGenerator.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/testutils/StringGenerator.java
@@ -1,0 +1,13 @@
+package com.hubspot.slack.client.testutils;
+
+import java.util.Collections;
+
+public class StringGenerator {
+  public static String generateStringWithLengthAndEllipsis(int length) {
+    return generateStringWithLength(length) + "...";
+  }
+
+  public static String generateStringWithLength(int length) {
+    return String.join("", Collections.nCopies(length, "a"));
+  }
+}


### PR DESCRIPTION
I implemented normalization of the data that serves informational purposes - label, hint, a placeholder. We don't want to normalize stuff like `name` or `value` because their values can be used as unique identifiers and this can break the consumer in a very unexpected way.

Example of previous behavior: Let's assume that the element label is limited to 24 characters. If we set `aaaaaaaaaaaaaaaaaaaaaaaaaa`(26 chars long) as a label, the model is going to fail on the build.
Current behavior: We are going to show `aaaaaaaaaaaaaaaaaaaaaa...` instead to fit into the limit.