### PR TITLE
Normalize Slack form element presentational data | Attempt 2

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackDialogFormTextElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackDialogFormTextElement.java
@@ -22,23 +22,20 @@ public abstract class AbstractSlackDialogFormTextElement extends SlackDialogForm
 
   public abstract Optional<String> getValue();
 
-  protected void validateBaseTextElementProps() {
-
-    super.validateBaseElementProperties();
-    if (getMinLength() < 0) {
-      throw new IllegalStateException("Min length cannot be negative, got " + getMinLength());
+  protected void validateBaseTextElementProps(AbstractSlackDialogFormTextElement normalized) {
+    super.validateBaseElementProperties(normalized);
+    int normalizedMinLength = normalized.getMinLength();
+    if (normalizedMinLength < 0) {
+      throw new IllegalStateException("Min length cannot be negative, got " + normalizedMinLength);
     }
 
-    if (getMaxLength() < 0) {
-      throw new IllegalStateException("Max length cannot be negative, got " + getMaxLength());
+    int normalizedMaxLength = normalized.getMaxLength();
+    if (normalizedMaxLength < 0) {
+      throw new IllegalStateException("Max length cannot be negative, got " + normalizedMaxLength);
     }
 
-    if (getMinLength() > getMaxLength()) {
-      throw new IllegalStateException("Min length must be <= max length, got " + getMinLength() + ", " + getMaxLength());
-    }
-
-    if (getHint().isPresent() && getHint().get().length() > 150) {
-      throw new IllegalStateException("Hint cannot exceed 150 chars, got '" + getHint().get() + "'");
+    if (normalizedMinLength > normalizedMaxLength) {
+      throw new IllegalStateException("Min length must be <= max length, got " + normalizedMinLength + ", " + normalizedMaxLength);
     }
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormSelectElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormSelectElement.java
@@ -16,12 +16,13 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.actions.SlackDataSource;
 import com.hubspot.slack.client.models.dialog.form.SlackFormElementTypes;
+import com.hubspot.slack.client.models.dialog.form.elements.helpers.SlackDialogElementNormalizer;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 @JsonInclude(Include.NON_EMPTY)
-public abstract class AbstractSlackFormSelectElement extends SlackDialogFormElement {
+public abstract class AbstractSlackFormSelectElement extends SlackDialogFormElement implements HasOptions {
   @Default
   @Override
   public SlackFormElementTypes getType() {
@@ -33,63 +34,69 @@ public abstract class AbstractSlackFormSelectElement extends SlackDialogFormElem
     return SlackDataSource.STATIC;
   }
 
-  public abstract List<SlackFormOption> getOptions();
   public abstract List<SlackFormOptionGroup> getOptionGroups();
   public abstract Optional<String> getValue();
   public abstract List<SlackFormOption> getSelectedOptions();
   public abstract Optional<Integer> getMinQueryLength();
 
   @Check
-  public void validate() {
-    super.validateBaseElementProperties();
+  public AbstractSlackFormSelectElement validate() {
+    AbstractSlackFormSelectElement normalized = SlackDialogElementNormalizer.normalize(this);
+    super.validateBaseElementProperties(normalized);
     List<String> errors = new ArrayList<>();
 
-    int numOptions = getOptions().size();
-    int numOptionGroups = getOptionGroups().size();
+    List<SlackFormOption> normalizedOptions = normalized.getOptions();
+    int numOptions = normalizedOptions.size();
+    List<SlackFormOptionGroup> normalizedOptionGroups = normalized.getOptionGroups();
+    int numOptionGroups = normalizedOptionGroups.size();
 
-    if (numOptions > 100) {
-      errors.add("Cannot have more than 100 options");
+    int maxOptionsNumber = SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER.getLimit();
+    if (numOptions > maxOptionsNumber) {
+      errors.add(String.format("Cannot have more than %s options", maxOptionsNumber));
     }
 
-    if (numOptionGroups > 100) {
-      errors.add("Cannot have more than 100 option groups");
+    int maxOptionGroupsNumber = SlackDialogFormElementLengthLimits.MAX_OPTION_GROUPS_NUMBER.getLimit();
+    if (numOptionGroups > maxOptionGroupsNumber) {
+      errors.add(String.format("Cannot have more than %s option groups", maxOptionGroupsNumber));
     }
 
-    if (getDataSource().equals(SlackDataSource.STATIC)) {
+    if (normalized.getDataSource().equals(SlackDataSource.STATIC)) {
       if (numOptions == 0 && numOptionGroups == 0) {
         errors.add("Either options or option groups are required for static data source types");
       }
     }
 
-    if (getValue().isPresent() && getDataSource().equals(SlackDataSource.EXTERNAL)) {
+    Optional<String> normalizedValue = normalized.getValue();
+    if (normalizedValue.isPresent() && normalized.getDataSource().equals(SlackDataSource.EXTERNAL)) {
       errors.add("Cannot use value for external data source, must use selected options");
     }
 
-    if (getValue().isPresent()) {
+    if (normalizedValue.isPresent()) {
       boolean valueIsSomeOptionValue = getOptions().stream()
-          .anyMatch(option -> option.getValue().equalsIgnoreCase(getValue().get()));
+          .anyMatch(option -> option.getValue().equalsIgnoreCase(normalizedValue.get()));
       if (!valueIsSomeOptionValue) {
         errors.add("Value must exactly match the value field for one provided option");
       }
     }
 
-    if (!getSelectedOptions().isEmpty()) {
-      if (getSelectedOptions().size() != 1) {
+    List<SlackFormOption> normalizedSelectedOptions = normalized.getSelectedOptions();
+    if (!normalizedSelectedOptions.isEmpty()) {
+      if (normalizedSelectedOptions.size() != 1) {
         errors.add("Selected options must be a single element array");
       }
-      if (!getOptionGroups().isEmpty()) {
-        boolean selectedOptionIsInOptionsGroup = getOptionGroups().stream()
+      if (!normalizedOptionGroups.isEmpty()) {
+        boolean selectedOptionIsInOptionsGroup = normalizedOptionGroups.stream()
             .map(SlackFormOptionGroup::getOptions)
             .collect(Collectors.toList())
             .stream()
             .flatMap(List::stream)
-            .anyMatch(option -> option.equals(getSelectedOptions().get(0)));
+            .anyMatch(option -> option.equals(normalizedSelectedOptions.get(0)));
         if (!selectedOptionIsInOptionsGroup) {
           errors.add("Selected option must exactly match an option in the provided options groups");
         }
-      } else if (!getOptions().isEmpty()) {
-        boolean selectedOptionIsInOptions = getOptions().stream()
-            .anyMatch(option -> option.equals(getSelectedOptions().get(0)));
+      } else if (!normalizedOptions.isEmpty()) {
+        boolean selectedOptionIsInOptions = normalizedOptions.stream()
+            .anyMatch(option -> option.equals(normalizedSelectedOptions.get(0)));
         if (!selectedOptionIsInOptions) {
           errors.add("Selected option must exactly match an option in the provided options");
         }
@@ -99,5 +106,6 @@ public abstract class AbstractSlackFormSelectElement extends SlackDialogFormElem
     if (!errors.isEmpty()) {
       throw new IllegalStateException(errors.toString());
     }
+    return normalized;
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextElement.java
@@ -1,5 +1,7 @@
 package com.hubspot.slack.client.models.dialog.form.elements;
 
+import java.util.Optional;
+
 import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
@@ -10,6 +12,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.dialog.form.SlackFormElementTypes;
+import com.hubspot.slack.client.models.dialog.form.elements.helpers.SlackDialogElementNormalizer;
 
 @Immutable
 @HubSpotStyle
@@ -23,19 +26,28 @@ public abstract class AbstractSlackFormTextElement extends AbstractSlackDialogFo
   }
 
   @Check
-  public void validate() {
-    super.validateBaseTextElementProps();
+  public AbstractSlackFormTextElement validate() {
+    AbstractSlackFormTextElement normalized = SlackDialogElementNormalizer.normalize(this);
+    super.validateBaseTextElementProps(normalized);
 
-    if (getMaxLength() > 150) {
-      throw new IllegalStateException("Form text element cannot have max length > 150 chars, got " + getMaxLength());
+    int normalizedMaxLength = normalized.getMaxLength();
+    int maxTextElementValueLength = SlackDialogFormElementLengthLimits.MAX_TEXT_ELEMENT_VALUE_LENGTH.getLimit();
+    if (normalizedMaxLength > maxTextElementValueLength) {
+      String errorMessage = String.format("Form text element cannot have max length > %s chars, got %s", maxTextElementValueLength, normalizedMaxLength);
+      throw new IllegalStateException(errorMessage);
     }
 
-    if (getMinLength() > 150) {
-      throw new IllegalStateException("Form text element cannot have min length > 150 chars, got " + getMinLength());
+    int normalizedMinLength = normalized.getMinLength();
+    if (normalizedMinLength > maxTextElementValueLength) {
+      String errorMessage = String.format("Form text element cannot have min length > %s chars, got %s", maxTextElementValueLength, normalizedMinLength);
+      throw new IllegalStateException(errorMessage);
     }
 
-    if (getValue().isPresent() && getValue().get().length() > 150) {
-      throw new IllegalStateException("Value cannot exceed 150 chars, got '" + getValue().get() + "'");
+    Optional<String> value = normalized.getValue();
+    if (value.isPresent() && value.get().length() > maxTextElementValueLength) {
+      String errorMessage = String.format("Value cannot exceed %s chars, got %s", maxTextElementValueLength, value.get());
+      throw new IllegalStateException(errorMessage);
     }
+    return normalized;
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/HasLabel.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/HasLabel.java
@@ -1,0 +1,5 @@
+package com.hubspot.slack.client.models.dialog.form.elements;
+
+public interface HasLabel {
+  String getLabel();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/HasOptions.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/HasOptions.java
@@ -1,0 +1,7 @@
+package com.hubspot.slack.client.models.dialog.form.elements;
+
+import java.util.List;
+
+public interface HasOptions {
+  List<SlackFormOption> getOptions();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackDialogFormElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackDialogFormElement.java
@@ -5,26 +5,40 @@ import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hubspot.slack.client.models.dialog.form.SlackFormElementTypes;
 
-public abstract class SlackDialogFormElement {
+public abstract class SlackDialogFormElement implements HasLabel {
   public abstract SlackFormElementTypes getType();
+
   public abstract String getName();
-  public abstract String getLabel();
+
   public abstract Optional<String> getPlaceholder();
 
   @JsonProperty("optional")
   public abstract Optional<Boolean> isOptional();
 
-  protected void validateBaseElementProperties() {
-    if (getLabel().length() > 24) {
-      throw new IllegalStateException("Label cannot exceed 24 chars, got " + getLabel());
+  protected void validateBaseElementProperties(SlackDialogFormElement normalized) {
+    String normalizedLabel = normalized.getLabel();
+    int maxLabelLength = SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH.getLimit();
+    if (normalizedLabel.length() > maxLabelLength) {
+      String errorMessage = String.format("Label cannot exceed %s chars, got %s", maxLabelLength, normalizedLabel);
+      throw new IllegalStateException(errorMessage);
     }
 
-    if (getName().length() > 300) {
-      throw new IllegalStateException("Name cannot exceed 300 chars, got " + getName());
+    String normalizedName = normalized.getName();
+    int maxNameLength = SlackDialogFormElementLengthLimits.MAX_NAME_LENGTH.getLimit();
+    if (normalizedName.length() > maxNameLength) {
+      String errorMessage = String.format("Name cannot exceed %s chars, got %s", maxNameLength, normalizedName);
+      throw new IllegalStateException(errorMessage);
     }
 
-    if (getPlaceholder().isPresent() && getPlaceholder().get().length() > 150) {
-      throw new IllegalStateException("Placeholder length cannot exceed 150 chars, got " + getPlaceholder().get());
+    Optional<String> normalizedPlaceholder = normalized.getPlaceholder();
+    int maxPlaceholderLength = SlackDialogFormElementLengthLimits.MAX_PLACEHOLDER_LENGTH.getLimit();
+    if (normalizedPlaceholder.isPresent() && normalizedPlaceholder.get().length() > maxPlaceholderLength) {
+      String errorMessage = String.format(
+          "Placeholder cannot exceed %s chars, got %s",
+          maxPlaceholderLength,
+          normalizedPlaceholder.get()
+      );
+      throw new IllegalStateException(errorMessage);
     }
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackDialogFormElementLengthLimits.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackDialogFormElementLengthLimits.java
@@ -1,0 +1,24 @@
+package com.hubspot.slack.client.models.dialog.form.elements;
+
+public enum SlackDialogFormElementLengthLimits {
+  MAX_LABEL_LENGTH(24),
+  MAX_NAME_LENGTH(300),
+   MAX_PLACEHOLDER_LENGTH(150),
+   MAX_HINT_LENGTH(150),
+   MAX_TEXT_ELEMENT_VALUE_LENGTH(150),
+  MAX_TEXT_AREA_ELEMENT_VALUE_LENGTH(3000),
+   MAX_OPTION_LABEL_LENGTH(75),
+   MAX_OPTION_VALUE_LENGTH(75),
+   MAX_OPTIONS_NUMBER(100),
+   MAX_OPTION_GROUPS_NUMBER(100);
+
+  private final int limit;
+
+  SlackDialogFormElementLengthLimits(int limit) {
+    this.limit = limit;
+  }
+
+  public int getLimit() {
+    return limit;
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionIF.java
@@ -7,32 +7,38 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Strings;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.dialog.form.elements.helpers.SlackDialogElementNormalizer;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface SlackFormOptionIF {
-  String getLabel();
+public interface SlackFormOptionIF extends HasLabel{
   String getValue();
 
   @Check
-  default void validate() {
+  default SlackFormOptionIF validate() {
+    SlackFormOptionIF normalized = SlackDialogElementNormalizer.normalize(this);
     if (Strings.isNullOrEmpty(getLabel())) {
       throw new IllegalStateException("Must provide a label");
     }
 
-    String label = getLabel();
-    if (label.length() > 75) {
-      throw new IllegalStateException("Label cannot exceed 75 chars - '" + label + "'");
+    String label = normalized.getLabel();
+    int maxOptionLabelLength = SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH.getLimit();
+    if (label.length() > maxOptionLabelLength) {
+      String errorMessage = String.format("Label cannot exceed %s chars - '%s'", maxOptionLabelLength, label);
+      throw new IllegalStateException(errorMessage);
     }
 
     if (Strings.isNullOrEmpty(getValue())) {
       throw new IllegalStateException("Must provide a value");
     }
 
-    String value = getValue();
-    if (value.length() > 75) {
-      throw new IllegalStateException("Value cannot exceed 75 chars - '" + value + "'");
+    String value = normalized.getValue();
+    int maxOptionValueLength = SlackDialogFormElementLengthLimits.MAX_OPTION_VALUE_LENGTH.getLimit();
+    if (value.length() > maxOptionValueLength) {
+      String errorMessage = String.format("Value cannot exceed %s chars - '%s'", maxOptionValueLength, value);
+      throw new IllegalStateException(errorMessage);
     }
+    return normalized;
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/helpers/SlackDialogElementNormalizer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/helpers/SlackDialogElementNormalizer.java
@@ -28,10 +28,12 @@ public class SlackDialogElementNormalizer {
     if (shouldNormalizePlaceholder(element)
         || shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH)
         || shouldNormalize(element.getHint(), SlackDialogFormElementLengthLimits.MAX_HINT_LENGTH)) {
-      return SlackFormTextElement.copyOf(element)
-          .withPlaceholder(normalizePlaceholder(element))
-          .withLabel(normalizeLabel(element))
-          .withHint(normalizeHint(element));
+      return SlackFormTextElement.builder()
+          .from(element)
+          .setPlaceholder(normalizePlaceholder(element))
+          .setLabel(normalizeLabel(element))
+          .setHint(normalizeHint(element))
+          .build();
     }
     return element;
   }
@@ -40,10 +42,12 @@ public class SlackDialogElementNormalizer {
     if (shouldNormalizePlaceholder(element)
         || shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH)
         || shouldNormalize(element.getHint(), SlackDialogFormElementLengthLimits.MAX_HINT_LENGTH)) {
-      return SlackFormTextareaElement.copyOf(element)
-          .withPlaceholder(normalizePlaceholder(element))
-          .withLabel(normalizeLabel(element))
-          .withHint(normalizeHint(element));
+      return SlackFormTextareaElement.builder()
+          .from(element)
+          .setPlaceholder(normalizePlaceholder(element))
+          .setLabel(normalizeLabel(element))
+          .setHint(normalizeHint(element))
+          .build();
     }
     return element;
   }
@@ -53,11 +57,13 @@ public class SlackDialogElementNormalizer {
         || shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH)
         || shouldNormalize(element.getOptionGroups(), SlackDialogFormElementLengthLimits.MAX_OPTION_GROUPS_NUMBER)
         || shouldNormalizeOptions(element)) {
-      return SlackFormSelectElement.copyOf(element)
-          .withPlaceholder(normalizePlaceholder(element))
-          .withLabel(normalizeLabel(element))
-          .withOptionGroups(normalizeOptionGroups(element))
-          .withOptions(normalizeOptions(element));
+      return SlackFormSelectElement.builder()
+          .from(element)
+          .setPlaceholder(normalizePlaceholder(element))
+          .setLabel(normalizeLabel(element))
+          .setOptionGroups(normalizeOptionGroups(element))
+          .setOptions(normalizeOptions(element))
+          .build();
     }
     return element;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/helpers/SlackDialogElementNormalizer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/helpers/SlackDialogElementNormalizer.java
@@ -1,0 +1,156 @@
+package com.hubspot.slack.client.models.dialog.form.elements.helpers;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.google.common.collect.Iterables;
+import com.hubspot.slack.client.models.dialog.form.elements.AbstractSlackDialogFormTextElement;
+import com.hubspot.slack.client.models.dialog.form.elements.AbstractSlackFormSelectElement;
+import com.hubspot.slack.client.models.dialog.form.elements.AbstractSlackFormTextElement;
+import com.hubspot.slack.client.models.dialog.form.elements.AbstractSlackFormTextareaElement;
+import com.hubspot.slack.client.models.dialog.form.elements.HasLabel;
+import com.hubspot.slack.client.models.dialog.form.elements.HasOptions;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackDialogFormElement;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackDialogFormElementLengthLimits;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackFormOption;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackFormOptionGroup;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackFormOptionGroupIF;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackFormOptionIF;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackFormSelectElement;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackFormTextElement;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackFormTextareaElement;
+
+public class SlackDialogElementNormalizer {
+  private SlackDialogElementNormalizer() {
+  }
+
+  public static AbstractSlackFormTextElement normalize(AbstractSlackFormTextElement element) {
+    if (shouldNormalizePlaceholder(element)
+        || shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH)
+        || shouldNormalize(element.getHint(), SlackDialogFormElementLengthLimits.MAX_HINT_LENGTH)) {
+      return SlackFormTextElement.copyOf(element)
+          .withPlaceholder(normalizePlaceholder(element))
+          .withLabel(normalizeLabel(element))
+          .withHint(normalizeHint(element));
+    }
+    return element;
+  }
+
+  public static AbstractSlackFormTextareaElement normalize(AbstractSlackFormTextareaElement element) {
+    if (shouldNormalizePlaceholder(element)
+        || shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH)
+        || shouldNormalize(element.getHint(), SlackDialogFormElementLengthLimits.MAX_HINT_LENGTH)) {
+      return SlackFormTextareaElement.copyOf(element)
+          .withPlaceholder(normalizePlaceholder(element))
+          .withLabel(normalizeLabel(element))
+          .withHint(normalizeHint(element));
+    }
+    return element;
+  }
+
+  public static AbstractSlackFormSelectElement normalize(AbstractSlackFormSelectElement element) {
+    if (shouldNormalizePlaceholder(element)
+        || shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH)
+        || shouldNormalize(element.getOptionGroups(), SlackDialogFormElementLengthLimits.MAX_OPTION_GROUPS_NUMBER)
+        || shouldNormalizeOptions(element)) {
+      return SlackFormSelectElement.copyOf(element)
+          .withPlaceholder(normalizePlaceholder(element))
+          .withLabel(normalizeLabel(element))
+          .withOptionGroups(normalizeOptionGroups(element))
+          .withOptions(normalizeOptions(element));
+    }
+    return element;
+  }
+
+  public static SlackFormOptionGroupIF normalize(SlackFormOptionGroupIF element) {
+    if (shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH)
+        || shouldNormalizeOptions(element)) {
+      return SlackFormOptionGroup.builder()
+          .from(element)
+          .setLabel(normalizeLabel(element))
+          .setOptions(normalizeOptions(element))
+          .build();
+    }
+    return element;
+  }
+
+  private static boolean shouldNormalizeOptions(HasOptions element) {
+    return shouldNormalize(element.getOptions(), SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER);
+  }
+
+  public static SlackFormOptionIF normalize(SlackFormOptionIF element) {
+    if (shouldNormalizeLabel(element, SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH)) {
+      return SlackFormOption.copyOf(element).withLabel(normalizeLabel(element));
+    }
+    return element;
+  }
+
+  private static boolean shouldNormalize(List listOfFormElements, SlackDialogFormElementLengthLimits maxListSize) {
+    return listOfFormElements.size() > maxListSize.getLimit();
+  }
+
+  private static boolean shouldNormalizePlaceholder(SlackDialogFormElement element) {
+    return shouldNormalize(element.getPlaceholder(), SlackDialogFormElementLengthLimits.MAX_PLACEHOLDER_LENGTH);
+  }
+
+  private static boolean shouldNormalizeLabel(HasLabel element, SlackDialogFormElementLengthLimits maxLabelLength) {
+    return shouldNormalize(element.getLabel(), maxLabelLength);
+  }
+
+  private static boolean shouldNormalize(Optional<String> stringOptional,
+                                         SlackDialogFormElementLengthLimits maxPlaceholderLength) {
+    return stringOptional.isPresent() && shouldNormalize(stringOptional.get(), maxPlaceholderLength);
+  }
+
+  private static boolean shouldNormalize(String string,
+                                         SlackDialogFormElementLengthLimits maxPlaceholderLength) {
+    return string.length() > maxPlaceholderLength.getLimit();
+  }
+
+  private static String normalizeLabel(SlackFormOptionIF option) {
+    return normalizeIfLongerThan(option.getLabel(), SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH.getLimit());
+  }
+
+  private static String normalizeLabel(SlackFormOptionGroupIF optionGroup) {
+    return normalizeIfLongerThan(optionGroup.getLabel(), SlackDialogFormElementLengthLimits.MAX_OPTION_LABEL_LENGTH.getLimit());
+  }
+
+  private static Iterable<SlackFormOptionGroup> normalizeOptionGroups(AbstractSlackFormSelectElement element) {
+    return Iterables.limit(element.getOptionGroups(), SlackDialogFormElementLengthLimits.MAX_OPTION_GROUPS_NUMBER.getLimit());
+  }
+
+  private static Iterable<SlackFormOption> normalizeOptions(AbstractSlackFormSelectElement element) {
+    return Iterables.limit(element.getOptions(), SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER.getLimit());
+  }
+
+  private static Iterable<SlackFormOption> normalizeOptions(SlackFormOptionGroupIF element) {
+    return Iterables.limit(element.getOptions(), SlackDialogFormElementLengthLimits.MAX_OPTIONS_NUMBER.getLimit());
+  }
+
+  private static String normalizeLabel(SlackDialogFormElement element) {
+    return normalizeIfLongerThan(element.getLabel(), SlackDialogFormElementLengthLimits.MAX_LABEL_LENGTH.getLimit());
+  }
+
+  private static Optional<String> normalizePlaceholder(SlackDialogFormElement element) {
+    return element.getPlaceholder()
+        .map(placeholder ->
+            normalizeIfLongerThan(
+                placeholder,
+                SlackDialogFormElementLengthLimits.MAX_PLACEHOLDER_LENGTH.getLimit()
+            ));
+  }
+
+  private static Optional<String> normalizeHint(AbstractSlackDialogFormTextElement element) {
+    return element.getHint()
+        .map(hint -> normalizeIfLongerThan(hint, SlackDialogFormElementLengthLimits.MAX_HINT_LENGTH.getLimit()));
+  }
+
+  private static String normalizeIfLongerThan(String label, int maxLength) {
+    if (label.length() > maxLength) {
+      String ellipsis = "...";
+      int endIndex = (maxLength - ellipsis.length()) - 1;
+      return label.substring(0, endIndex) + ellipsis;
+    }
+    return label;
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackDialogFormElementTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackDialogFormElementTest.java
@@ -1,0 +1,45 @@
+package com.hubspot.slack.client.models.dialog.form.elements;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.junit.Test;
+
+import com.hubspot.slack.client.testutils.StringGenerator;
+
+public class SlackDialogFormElementTest {
+
+  @Test
+  public void itFailsToBuildDialogFormElementForMissingTooLongName() {
+    String tooLongName = StringGenerator.generateStringWithLength(301);
+    try {
+      SlackFormTextElement.builder().setLabel("ignored").setName(tooLongName).build();
+    } catch (IllegalStateException ise) {
+      assertThat(ise.getMessage()).contains("Name cannot exceed 300 chars, got " + tooLongName);
+      return;
+    }
+
+    fail("Didn't throw exception");
+  }
+
+  @Test
+  public void itNormalizesLongLabelToBuildFormSelectElement() {
+    SlackFormTextElement slackFormTextElement = SlackFormTextElement.builder()
+        .setLabel(StringGenerator.generateStringWithLength(25))
+        .setName("ignored")
+        .build();
+    String expectedLabel = StringGenerator.generateStringWithLengthAndEllipsis(20);
+    assertThat(slackFormTextElement.getLabel()).isEqualTo(expectedLabel);
+  }
+
+  @Test
+  public void itNormalizesLongPlaceholderToBuildFormSelectElement() {
+    SlackFormTextElement slackFormTextElement = SlackFormTextElement.builder()
+        .setLabel("ignored")
+        .setName("ignored")
+        .setPlaceholder(StringGenerator.generateStringWithLength(151))
+        .build();
+    String expectedLabel = StringGenerator.generateStringWithLengthAndEllipsis(146);
+    assertThat(slackFormTextElement.getPlaceholder()).hasValue(expectedLabel);
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionsTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionsTest.java
@@ -210,4 +210,23 @@ public class SlackFormOptionsTest {
         .build();
     assertThat(optionGroup.getOptions()).hasSize(100);
   }
+
+  @Test
+  public void itNormalizesOptionsListToBuildFormSelectElement() {
+    List<SlackFormOption> options = new ArrayList<>();
+
+    for (int i = 0; i < 101; i++) {
+      options.add(SlackFormOption.builder()
+          .setLabel("label-" + String.valueOf(i))
+          .setValue("value-" + String.valueOf(i))
+          .build());
+    }
+
+    SlackFormSelectElement slackFormSelectElement = SlackFormSelectElement.builder()
+        .setLabel("ignored")
+        .setName("ignored")
+        .setOptions(options)
+        .build();
+    assertThat(slackFormSelectElement.getOptions()).hasSize(100);
+  }
 }

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionsTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionsTest.java
@@ -4,12 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
 
 import com.hubspot.slack.client.models.actions.SlackDataSource;
+import com.hubspot.slack.client.testutils.StringGenerator;
 
 public class SlackFormOptionsTest {
 
@@ -172,25 +172,29 @@ public class SlackFormOptionsTest {
   }
 
   @Test
-  public void itFailsToBuildFormSelectOptionGroupForLongLabel() {
-    try {
-      SlackFormOptionGroup.builder()
-          .setLabel(String.join("", Collections.nCopies(76, "a"))) // long label
-          .addOptions(SlackFormOption.builder()
-              .setLabel("label")
-              .setValue("value")
-              .build()
-          ).build();
-    } catch (IllegalStateException ise) {
-      assertThat(ise.getMessage()).contains("Label cannot exceed 75 chars");
-      return;
-    }
-
-    fail("Didn't throw exception");
+  public void itNormalizesLongLabelToBuildFormSelectOptionGroup() {
+    SlackFormOptionGroup optionGroup = SlackFormOptionGroup.builder()
+        .setLabel(StringGenerator.generateStringWithLength(76))
+        .addOptions(SlackFormOption.builder()
+            .setLabel("label")
+            .setValue("value")
+            .build()
+        ).build();
+    String expectedLabel = StringGenerator.generateStringWithLengthAndEllipsis(71);
+    assertThat(optionGroup.getLabel()).isEqualTo(expectedLabel);
   }
 
   @Test
-  public void itFailsToBuildFormSelectOptionGroupForInvalidNumberOfOptions() {
+  public void itNormalizesLongLabelToBuildFormSelectOption() {
+    SlackFormOption option = SlackFormOption.builder()
+        .setLabel(StringGenerator.generateStringWithLength(76))
+        .setValue("value-1").build();
+    String expectedLabel = StringGenerator.generateStringWithLengthAndEllipsis(71);
+    assertThat(option.getLabel()).isEqualTo(expectedLabel);
+  }
+
+  @Test
+  public void itNormalizesOptionsListToBuildFormSelectOptionGroup() {
     List<SlackFormOption> options = new ArrayList<>();
 
     for (int i = 0; i < 101; i++) {
@@ -200,16 +204,10 @@ public class SlackFormOptionsTest {
           .build());
     }
 
-    try {
-      SlackFormOptionGroup.builder()
-          .setLabel("label")
-          .setOptions(options)
-          .build();
-    } catch (IllegalStateException ise) {
-      assertThat(ise.getMessage()).contains("Cannot have more than 100 option groups");
-      return;
-    }
-
-    fail("Didn't throw exception");
+    SlackFormOptionGroup optionGroup = SlackFormOptionGroup.builder()
+        .setLabel("label")
+        .setOptions(options)
+        .build();
+    assertThat(optionGroup.getOptions()).hasSize(100);
   }
 }

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormTextElementTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormTextElementTest.java
@@ -1,0 +1,36 @@
+package com.hubspot.slack.client.models.dialog.form.elements;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.junit.Test;
+
+import com.hubspot.slack.client.testutils.StringGenerator;
+
+public class SlackFormTextElementTest{
+
+  @Test
+  public void itNormalizesLongHintToBuildFormSelectElement() {
+    SlackFormTextElement optionGroup = SlackFormTextElement.builder()
+        .setLabel("ignored")
+        .setName("ignored")
+        .setHint(StringGenerator.generateStringWithLength(151))
+        .build();
+    String expectedLabel = StringGenerator.generateStringWithLengthAndEllipsis(146);
+    assertThat(optionGroup.getHint()).hasValue(expectedLabel);
+  }
+
+  @Test
+  public void itFailsToBuildDialogFormElementForMissingTooLongValue() {
+    String tooLongValue = StringGenerator.generateStringWithLength(151);
+    try {
+      SlackFormTextElement.builder().setLabel("ignored").setName("ignored").setValue(tooLongValue).build();
+    } catch (IllegalStateException ise) {
+      String errorMessage = String.format("Value cannot exceed 150 chars, got %s", tooLongValue);
+      assertThat(ise.getMessage()).contains(errorMessage);
+      return;
+    }
+
+    fail("Didn't throw exception");
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormTextareaElementTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormTextareaElementTest.java
@@ -1,0 +1,36 @@
+package com.hubspot.slack.client.models.dialog.form.elements;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.junit.Test;
+
+import com.hubspot.slack.client.testutils.StringGenerator;
+
+public class SlackFormTextareaElementTest {
+
+  @Test
+  public void itNormalizesLongHintToBuildFormSelectElement() {
+    SlackFormTextareaElement textareaElement = SlackFormTextareaElement.builder()
+        .setLabel("ignored")
+        .setName("ignored")
+        .setHint(StringGenerator.generateStringWithLength(151))
+        .build();
+    String expectedLabel = StringGenerator.generateStringWithLengthAndEllipsis(146);
+    assertThat(textareaElement.getHint()).hasValue(expectedLabel);
+  }
+
+  @Test
+  public void itFailsToBuildDialogFormElementForMissingTooLongValue() {
+    String tooLongValue = StringGenerator.generateStringWithLength(3001);
+    try {
+      SlackFormTextareaElement.builder().setLabel("ignored").setName("ignored").setValue(tooLongValue).build();
+    } catch (IllegalStateException ise) {
+      String errorMessage = String.format("Value cannot exceed 3000 chars, got %s", tooLongValue);
+      assertThat(ise.getMessage()).contains(errorMessage);
+      return;
+    }
+
+    fail("Didn't throw exception");
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/testutils/StringGenerator.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/testutils/StringGenerator.java
@@ -1,0 +1,13 @@
+package com.hubspot.slack.client.testutils;
+
+import java.util.Collections;
+
+public class StringGenerator {
+  public static String generateStringWithLengthAndEllipsis(int length) {
+    return generateStringWithLength(length) + "...";
+  }
+
+  public static String generateStringWithLength(int length) {
+    return String.join("", Collections.nCopies(length, "a"));
+  }
+}


### PR DESCRIPTION
Same as https://github.com/HubSpot/slack-client/pull/256 but fixed stackoverflow error during normalization caused by cyclic constructor calls in `with` methods.