### PR TITLE
Add dispatch_action field to Input Block

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/InputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/InputIF.java
@@ -34,4 +34,6 @@ public interface InputIF extends Block {
 
   @JsonProperty("optional")
   Optional<Boolean> isOptional();
+
+  Optional<Boolean> getDispatchAction();
 }


### PR DESCRIPTION
`dispatch_action` field should be set to true for the [Input Block](https://api.slack.com/reference/block-kit/blocks#input) in order to be notified about user interaction with this block. E.g.: Slack will notify the app when the user selects an option from the select menu.