### PR TITLE
Change `UserProfile::statusExpiration` type to `long`

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/users/UserProfileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/users/UserProfileIF.java
@@ -3,9 +3,9 @@ package com.hubspot.slack.client.models.users;
 import java.util.Map;
 import java.util.Optional;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import org.immutables.value.Value.Immutable;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -29,7 +29,7 @@ public interface UserProfileIF {
   Optional<String> getEmail();
   Optional<String> getStatusText();
   Optional<String> getStatusEmoji();
-  Optional<Integer> getStatusExpiration();
+  Optional<Long> getStatusExpiration();
   Optional<String> getTitle();
   Optional<String> getPhone();
   Optional<String> getSkype();

--- a/slack-base/src/test/resources/user_change.json
+++ b/slack-base/src/test/resources/user_change.json
@@ -20,7 +20,7 @@
         "fields": null,
         "status_text": "",
         "status_emoji": "",
-        "status_expiration": 0,
+        "status_expiration": 2841800400,
         "avatar_hash": "g18e65e0de31",
         "email": "jisuvasug@eos2mail.com",
         "image_24": "https:\/\/secure.gravatar.com\/avatar\/18e65e0de317b3fa3e5aa41489e1a0cf.jpg?s=24&d=https%3A%2F%2Fa.slack-edge.com%2F66f9%2Fimg%2Favatars%2Fava_0008-24.png",


### PR DESCRIPTION
We've recently got `user_change` event with the user profile that has `status_expiration` equal `2841800400(year 2060)`. It isn't possible to set the expiration time like this in Slack app so I assume this was done via API. In order to avoid such issues in the future, I decided to change the type and hope that Slack won't allow setting something like `BigInteger` as `status_expiration` via API.