### PR TITLE
Normalize some of blocks' presentational data

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/BlockElementLengthLimits.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/BlockElementLengthLimits.java
@@ -1,0 +1,24 @@
+package com.hubspot.slack.client.models.blocks;
+
+public enum BlockElementLengthLimits {
+  MAX_INPUT_LABEL_LENGTH(2000),
+  MAX_HINT_LENGTH(2000),
+  MAX_OPTION_GROUPS_NUMBER(100),
+  MAX_OPTIONS_NUMBER(100),
+  MAX_PLAIN_TEXT_PLACEHOLDER_LENGTH(150),
+  MAX_OPTION_TEXT_LENGTH(75),
+  MAX_OPTION_GROUP_LABEL_LENGTH(75),
+  MAX_OPTION_VALUE_LENGTH(75),
+  MAX_CHECKBOXES_NUMBER(10),
+  MAX_RADIO_BUTTONS_NUMBER(10);
+
+  private final int limit;
+
+  BlockElementLengthLimits(int limit) {
+    this.limit = limit;
+  }
+
+  public int getLimit() {
+    return limit;
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/InputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/InputIF.java
@@ -3,6 +3,7 @@ package com.hubspot.slack.client.models.blocks;
 import java.util.Optional;
 
 import org.immutables.value.Value;
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -36,4 +37,9 @@ public interface InputIF extends Block {
   Optional<Boolean> isOptional();
 
   Optional<Boolean> getDispatchAction();
+
+  @Check
+  default InputIF validate() {
+    return SlackBlockNormalizer.normalize(this);
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SlackBlockNormalizer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SlackBlockNormalizer.java
@@ -1,0 +1,156 @@
+package com.hubspot.slack.client.models.blocks;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.google.common.collect.Iterables;
+import com.hubspot.slack.client.models.blocks.elements.Checkboxes;
+import com.hubspot.slack.client.models.blocks.elements.CheckboxesIF;
+import com.hubspot.slack.client.models.blocks.elements.PlainTextInput;
+import com.hubspot.slack.client.models.blocks.elements.PlainTextInputIF;
+import com.hubspot.slack.client.models.blocks.elements.RadioButtonGroup;
+import com.hubspot.slack.client.models.blocks.elements.RadioButtonGroupIF;
+import com.hubspot.slack.client.models.blocks.elements.StaticMultiSelectMenu;
+import com.hubspot.slack.client.models.blocks.elements.StaticMultiSelectMenuIF;
+import com.hubspot.slack.client.models.blocks.elements.StaticSelectMenu;
+import com.hubspot.slack.client.models.blocks.elements.StaticSelectMenuIF;
+import com.hubspot.slack.client.models.blocks.objects.Option;
+import com.hubspot.slack.client.models.blocks.objects.OptionGroup;
+import com.hubspot.slack.client.models.blocks.objects.OptionGroupIF;
+import com.hubspot.slack.client.models.blocks.objects.OptionIF;
+import com.hubspot.slack.client.models.blocks.objects.Text;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackDialogFormElementLengthLimits;
+
+public class SlackBlockNormalizer {
+  private SlackBlockNormalizer() {
+  }
+
+  public static InputIF normalize(InputIF input) {
+    if (shouldNormalize(input.getLabel(), BlockElementLengthLimits.MAX_INPUT_LABEL_LENGTH)
+        || shouldNormalize(input.getHint(), BlockElementLengthLimits.MAX_HINT_LENGTH)) {
+      return Input.builder()
+          .from(input)
+          .setLabel(normalize(input.getLabel(), BlockElementLengthLimits.MAX_INPUT_LABEL_LENGTH))
+          .setHint(normalize(input.getHint(), BlockElementLengthLimits.MAX_HINT_LENGTH))
+          .build();
+    }
+    return input;
+  }
+
+  public static PlainTextInputIF normalize(PlainTextInputIF plainTextInput) {
+    if (shouldNormalize(plainTextInput.getPlaceholder(), BlockElementLengthLimits.MAX_PLAIN_TEXT_PLACEHOLDER_LENGTH)) {
+      return PlainTextInput.builder()
+          .from(plainTextInput)
+          .setPlaceholder(normalize(plainTextInput.getPlaceholder(), BlockElementLengthLimits.MAX_PLAIN_TEXT_PLACEHOLDER_LENGTH))
+          .build();
+    }
+    return plainTextInput;
+  }
+
+  public static StaticMultiSelectMenuIF normalize(StaticMultiSelectMenuIF staticMultiSelectMenu) {
+    if (shouldNormalize(staticMultiSelectMenu.getOptionGroups(), BlockElementLengthLimits.MAX_OPTION_GROUPS_NUMBER)
+        || shouldNormalize(staticMultiSelectMenu.getOptions(), BlockElementLengthLimits.MAX_OPTIONS_NUMBER)) {
+      return StaticMultiSelectMenu.builder()
+          .from(staticMultiSelectMenu)
+          .setOptionGroups(normalizeOptionGroups(staticMultiSelectMenu.getOptionGroups()))
+          .setOptions(normalizeOptions(staticMultiSelectMenu.getOptions()))
+          .build();
+    }
+    return staticMultiSelectMenu;
+  }
+
+  public static StaticSelectMenuIF normalize(StaticSelectMenuIF staticSelectMenu) {
+    if (shouldNormalize(staticSelectMenu.getOptionGroups(), BlockElementLengthLimits.MAX_OPTION_GROUPS_NUMBER)
+        || shouldNormalize(staticSelectMenu.getOptions(), BlockElementLengthLimits.MAX_OPTIONS_NUMBER)) {
+      return StaticSelectMenu.builder()
+          .from(staticSelectMenu)
+          .setOptionGroups(normalizeOptionGroups(staticSelectMenu.getOptionGroups()))
+          .setOptions(normalizeOptions(staticSelectMenu.getOptions()))
+          .build();
+    }
+    return staticSelectMenu;
+  }
+
+  public static OptionGroupIF normalize(OptionGroupIF optionGroup) {
+    if (shouldNormalize(optionGroup.getOptions(), BlockElementLengthLimits.MAX_OPTIONS_NUMBER)
+        || shouldNormalize(optionGroup.getLabel(), BlockElementLengthLimits.MAX_OPTION_GROUP_LABEL_LENGTH)) {
+      return OptionGroup.builder()
+          .from(optionGroup)
+          .setOptions(normalizeOptions(optionGroup.getOptions()))
+          .setLabel(normalize(optionGroup.getLabel(), BlockElementLengthLimits.MAX_OPTION_GROUP_LABEL_LENGTH))
+          .build();
+    }
+    return optionGroup;
+  }
+
+  public static OptionIF normalize(OptionIF option) {
+    if (shouldNormalize(option.getText(), BlockElementLengthLimits.MAX_OPTION_TEXT_LENGTH)) {
+      return Option.builder()
+          .from(option)
+          .setText(normalize(option.getText(), BlockElementLengthLimits.MAX_OPTION_TEXT_LENGTH))
+          .build();
+    }
+    return option;
+  }
+
+  public static RadioButtonGroupIF normalize(RadioButtonGroupIF radioButtonGroup) {
+    if (shouldNormalize(radioButtonGroup.getOptions(), BlockElementLengthLimits.MAX_RADIO_BUTTONS_NUMBER)) {
+      return RadioButtonGroup.builder()
+          .from(radioButtonGroup)
+          .setOptions(normalizeOptions(radioButtonGroup.getOptions(), BlockElementLengthLimits.MAX_RADIO_BUTTONS_NUMBER))
+          .build();
+    }
+    return radioButtonGroup;
+  }
+
+  public static CheckboxesIF normalize(CheckboxesIF checkboxes) {
+    if (shouldNormalize(checkboxes.getOptions(), BlockElementLengthLimits.MAX_CHECKBOXES_NUMBER)) {
+      return Checkboxes.builder()
+          .from(checkboxes)
+          .setOptions(normalizeOptions(checkboxes.getOptions(), BlockElementLengthLimits.MAX_CHECKBOXES_NUMBER))
+          .build();
+    }
+    return checkboxes;
+  }
+
+  private static boolean shouldNormalize(Text text, BlockElementLengthLimits lengthLimit) {
+    return text.getText().length() > lengthLimit.getLimit();
+  }
+
+  private static boolean shouldNormalize(Optional<Text> textMaybe, BlockElementLengthLimits lengthLimit) {
+    return textMaybe.filter(text -> shouldNormalize(text, lengthLimit)).isPresent();
+  }
+
+  private static boolean shouldNormalize(List listOfFormElements, BlockElementLengthLimits maxListSize) {
+    return listOfFormElements.size() > maxListSize.getLimit();
+  }
+
+  private static Iterable<OptionGroup> normalizeOptionGroups(Iterable<OptionGroup> optionGroups) {
+    return Iterables.limit(optionGroups, SlackDialogFormElementLengthLimits.MAX_OPTION_GROUPS_NUMBER.getLimit());
+  }
+
+  private static Iterable<Option> normalizeOptions(List<Option> options) {
+    return normalizeOptions(options, BlockElementLengthLimits.MAX_OPTIONS_NUMBER);
+  }
+
+  private static Iterable<Option> normalizeOptions(List<Option> options, BlockElementLengthLimits lengthLimit) {
+    return Iterables.limit(options, lengthLimit.getLimit());
+  }
+
+  private static Optional<Text> normalize(Optional<Text> textMaybe, BlockElementLengthLimits lengthLimit) {
+    return textMaybe.map(text -> normalize(text, lengthLimit));
+  }
+
+  private static Text normalize(Text text, BlockElementLengthLimits lengthLimit) {
+    return Text.copyOf(text).withText(normalizeIfLongerThan(text.getText(), lengthLimit.getLimit()));
+  }
+
+  private static String normalizeIfLongerThan(String label, int maxLength) {
+    if (label.length() > maxLength) {
+      String ellipsis = "...";
+      int endIndex = (maxLength - ellipsis.length()) - 1;
+      return label.substring(0, endIndex) + ellipsis;
+    }
+    return label;
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/CheckboxesIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/CheckboxesIF.java
@@ -1,17 +1,20 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.immutables.value.Value;
+import org.immutables.value.Value.Check;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;
 import com.hubspot.slack.client.models.blocks.json.OptionOrOptionGroupDeserializer;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
 import com.hubspot.slack.client.models.blocks.objects.Option;
-import org.immutables.value.Value;
-
-import java.util.List;
-import java.util.Optional;
 
 @Value.Immutable
 @HubSpotStyle
@@ -37,4 +40,8 @@ public interface CheckboxesIF extends BlockElement, HasActionId {
   @JsonProperty("confirm")
   Optional<ConfirmationDialog> getConfirmationDialog();
 
+  @Check
+  default CheckboxesIF validate() {
+    return SlackBlockNormalizer.normalize(this);
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/PlainTextInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/PlainTextInputIF.java
@@ -3,12 +3,14 @@ package com.hubspot.slack.client.models.blocks.elements;
 import java.util.Optional;
 
 import org.immutables.value.Value;
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;
 import com.hubspot.slack.client.models.blocks.objects.Text;
 
 @Immutable
@@ -36,4 +38,9 @@ public interface PlainTextInputIF extends BlockElement, HasActionId {
   Optional<Integer> getMinLength();
 
   Optional<Integer> getMaxLength();
+
+  @Check
+  default PlainTextInputIF validate() {
+    return SlackBlockNormalizer.normalize(this);
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/RadioButtonGroupIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/RadioButtonGroupIF.java
@@ -4,12 +4,14 @@ import java.util.List;
 import java.util.Optional;
 
 import org.immutables.value.Value;
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
 import com.hubspot.slack.client.models.blocks.objects.Option;
 
@@ -35,4 +37,9 @@ public interface RadioButtonGroupIF extends BlockElement, HasActionId {
 
   @JsonProperty("confirm")
   Optional<ConfirmationDialog> getConfirmationDialog();
+
+  @Check
+  default RadioButtonGroupIF validate() {
+    return SlackBlockNormalizer.normalize(this);
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticMultiSelectMenuIF.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.immutables.value.Value;
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -11,6 +12,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;
 import com.hubspot.slack.client.models.blocks.json.OptionOrOptionGroupDeserializer;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
 import com.hubspot.slack.client.models.blocks.objects.Option;
@@ -46,4 +48,9 @@ public interface StaticMultiSelectMenuIF extends BlockElement, HasActionId {
 
   @JsonProperty("confirm")
   Optional<ConfirmationDialog> getConfirmationDialog();
+
+  @Check
+  default StaticMultiSelectMenuIF validate() {
+    return SlackBlockNormalizer.normalize(this);
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticSelectMenuIF.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.immutables.value.Value;
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -11,6 +12,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;
 import com.hubspot.slack.client.models.blocks.json.OptionOrOptionGroupDeserializer;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
 import com.hubspot.slack.client.models.blocks.objects.Option;
@@ -46,4 +48,9 @@ public interface StaticSelectMenuIF extends BlockElement, HasActionId {
 
   @JsonProperty("confirm")
   Optional<ConfirmationDialog> getConfirmationDialog();
+
+  @Check
+  default StaticSelectMenuIF validate() {
+    return SlackBlockNormalizer.normalize(this);
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionGroupIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionGroupIF.java
@@ -3,11 +3,13 @@ package com.hubspot.slack.client.models.blocks.objects;
 import java.util.List;
 
 import org.immutables.value.Value;
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;
 
 @Immutable
 @HubSpotStyle
@@ -18,4 +20,9 @@ public interface OptionGroupIF extends OptionOrOptionGroup {
 
   @Value.Parameter
   List<Option> getOptions();
+
+  @Check
+  default OptionGroupIF validate() {
+    return SlackBlockNormalizer.normalize(this);
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionIF.java
@@ -3,11 +3,13 @@ package com.hubspot.slack.client.models.blocks.objects;
 import java.util.Optional;
 
 import org.immutables.value.Value;
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;
 
 @Immutable
 @HubSpotStyle
@@ -22,4 +24,9 @@ public interface OptionIF extends OptionOrOptionGroup{
   Optional<Text> getDescription();
 
   Optional<String> getUrl();
+
+  @Check
+  default OptionIF validate() {
+    return SlackBlockNormalizer.normalize(this);
+  }
 }


### PR DESCRIPTION
Same as https://github.com/HubSpot/slack-client/pull/258 but for some of the BlockKit models.