### PR TITLE
Add getStringValue method to BlockKit inputs

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/UsersSelectInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/UsersSelectInputIF.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import org.immutables.value.Value.Immutable;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -13,4 +14,9 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface UsersSelectInputIF extends ViewInput {
   Optional<String> getSelectedUser();
+
+  @JsonIgnore
+  default Optional<String> getStringValue() {
+    return getSelectedUser();
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewConversationsSelectIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewConversationsSelectIF.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import org.immutables.value.Value.Immutable;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -13,4 +14,9 @@ import com.hubspot.immutables.style.HubSpotStyle;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ViewConversationsSelectIF extends ViewInput {
   Optional<String> getSelectedConversation();
+
+  @JsonIgnore
+  default Optional<String> getStringValue() {
+    return getSelectedConversation();
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewDatePickerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewDatePickerIF.java
@@ -1,24 +1,17 @@
 package com.hubspot.slack.client.models.interaction.views;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.hubspot.immutables.style.HubSpotStyle;
-import com.hubspot.slack.client.models.blocks.objects.Option;
+import java.time.LocalDate;
+import java.util.Optional;
 
 import org.immutables.value.Value;
 
-import java.time.LocalDate;
-import java.util.Optional;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
 
 @Value.Immutable
 @HubSpotStyle
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public interface ViewDatePickerIF extends ViewInput {
   Optional<LocalDate> getSelectedDate();
-
-  @JsonIgnore
-  default Optional<String> getStringValue() {
-   return Optional.of(getSelectedDate().toString());
-  };
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewDatePickerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewDatePickerIF.java
@@ -1,8 +1,11 @@
 package com.hubspot.slack.client.models.interaction.views;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.objects.Option;
+
 import org.immutables.value.Value;
 
 import java.time.LocalDate;
@@ -13,4 +16,9 @@ import java.util.Optional;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public interface ViewDatePickerIF extends ViewInput {
   Optional<LocalDate> getSelectedDate();
+
+  @JsonIgnore
+  default Optional<String> getStringValue() {
+   return Optional.of(getSelectedDate().toString());
+  };
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewExternalSelectIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewExternalSelectIF.java
@@ -1,5 +1,6 @@
 package com.hubspot.slack.client.models.interaction.views;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -13,4 +14,9 @@ import java.util.Optional;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public interface ViewExternalSelectIF extends ViewInput {
     Optional<Option> getSelectedOption();
+
+    @JsonIgnore
+    default Optional<String> getStringValue() {
+        return getSelectedOption().map(Option::getValue);
+    }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewInput.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewInput.java
@@ -1,5 +1,8 @@
 package com.hubspot.slack.client.models.interaction.views;
 
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -29,4 +32,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 )
 public interface ViewInput {
   ViewInputType getType();
+
+  @JsonIgnore
+  Optional<String> getStringValue();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewPlainTextInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewPlainTextInputIF.java
@@ -1,5 +1,6 @@
 package com.hubspot.slack.client.models.interaction.views;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -12,4 +13,9 @@ import java.util.Optional;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ViewPlainTextInputIF extends ViewInput {
   Optional<String> getValue();
+
+  @JsonIgnore
+  default Optional<String> getStringValue() {
+    return getValue();
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewRadioButtonGroupIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewRadioButtonGroupIF.java
@@ -1,5 +1,6 @@
 package com.hubspot.slack.client.models.interaction.views;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -16,4 +17,9 @@ import java.util.Optional;
 public interface ViewRadioButtonGroupIF extends ViewInput {
   @JsonDeserialize(contentUsing = OptionOrOptionGroupDeserializer.class)
   Optional<Option> getSelectedOption();
+
+  @JsonIgnore
+  default Optional<String> getStringValue() {
+    return getSelectedOption().map(Option::getValue);
+  }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewStaticSelectIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewStaticSelectIF.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import org.immutables.value.Value.Immutable;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -14,4 +15,9 @@ import com.hubspot.slack.client.models.blocks.objects.Option;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ViewStaticSelectIF extends ViewInput {
   Optional<Option> getSelectedOption();
+
+  @JsonIgnore
+  default Optional<String> getStringValue() {
+    return getSelectedOption().map(Option::getValue);
+  }
 }


### PR DESCRIPTION
Currently, each input type has its own type for the included value it is needed to handle each input separately. It is not convenient when handling a collection of inputs (consider situation when different BlockKit inputs are submitted for the same view). This PR adds a getter to the ViewInput interface to make values extraction more universal (return a String value). 
I decided that converting to String DatePicker and multiple checkboxes inputs makes no sense and I think it is OK to handle them as a special case.