### PR TITLE
Normalize option and option group lists in `BlocksLoadOptionsResponse`

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SlackBlockNormalizer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SlackBlockNormalizer.java
@@ -20,6 +20,8 @@ import com.hubspot.slack.client.models.blocks.objects.OptionGroupIF;
 import com.hubspot.slack.client.models.blocks.objects.OptionIF;
 import com.hubspot.slack.client.models.blocks.objects.Text;
 import com.hubspot.slack.client.models.dialog.form.elements.SlackDialogFormElementLengthLimits;
+import com.hubspot.slack.client.models.interaction.BlocksLoadOptionsResponse;
+import com.hubspot.slack.client.models.interaction.BlocksLoadOptionsResponseIF;
 
 public class SlackBlockNormalizer {
   private SlackBlockNormalizer() {
@@ -69,6 +71,18 @@ public class SlackBlockNormalizer {
           .build();
     }
     return staticSelectMenu;
+  }
+
+  public static BlocksLoadOptionsResponseIF normalize(BlocksLoadOptionsResponseIF blocksLoadOptionsResponse) {
+    if (shouldNormalize(blocksLoadOptionsResponse.getOptionGroups(), BlockElementLengthLimits.MAX_OPTION_GROUPS_NUMBER)
+        || shouldNormalize(blocksLoadOptionsResponse.getOptions(), BlockElementLengthLimits.MAX_OPTIONS_NUMBER)) {
+      return BlocksLoadOptionsResponse.builder()
+          .from(blocksLoadOptionsResponse)
+          .setOptionGroups(normalizeOptionGroups(blocksLoadOptionsResponse.getOptionGroups()))
+          .setOptions(normalizeOptions(blocksLoadOptionsResponse.getOptions()))
+          .build();
+    }
+    return blocksLoadOptionsResponse;
   }
 
   public static OptionGroupIF normalize(OptionGroupIF optionGroup) {

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlocksLoadOptionsResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlocksLoadOptionsResponseIF.java
@@ -1,16 +1,19 @@
 package com.hubspot.slack.client.models.interaction;
 
+import java.util.List;
+
+import org.immutables.value.Value.Check;
+import org.immutables.value.Value.Immutable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.BaseSlackOptionsResponse;
+import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;
 import com.hubspot.slack.client.models.blocks.objects.Option;
 import com.hubspot.slack.client.models.blocks.objects.OptionGroup;
-import org.immutables.value.Value.Immutable;
-
-import java.util.List;
 
 @Immutable
 @HubSpotStyle
@@ -21,4 +24,9 @@ public interface BlocksLoadOptionsResponseIF extends BaseSlackOptionsResponse {
 
   @JsonInclude(Include.NON_EMPTY)
   List<OptionGroup> getOptionGroups();
+
+  @Check
+  default BlocksLoadOptionsResponseIF validate() {
+    return SlackBlockNormalizer.normalize(this);
+  }
 }


### PR DESCRIPTION
Limit the number of dynamically fetched options in a single place to avoid runtime failures from Slack.