### PR TITLE
Add SlackOptionsResponse model for Dialog Options handling

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/BaseSlackOptionsResponse.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/BaseSlackOptionsResponse.java
@@ -1,4 +1,14 @@
 package com.hubspot.slack.client.models;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.hubspot.slack.client.models.interaction.BlocksLoadOptionsResponse;
+import com.hubspot.slack.client.models.interaction.SlackOptionsResponse;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = SlackOptionsResponse.class, name = SlackOptionsResponse.TYPE),
+    @JsonSubTypes.Type(value = BlocksLoadOptionsResponse.class, name = BlocksLoadOptionsResponse.TYPE),
+})
 public interface BaseSlackOptionsResponse {
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlocksLoadOptionsResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlocksLoadOptionsResponseIF.java
@@ -2,7 +2,6 @@ package com.hubspot.slack.client.models.interaction;
 
 import java.util.List;
 
-import org.immutables.value.Value.Derived;
 import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 
@@ -21,11 +20,6 @@ import com.hubspot.slack.client.models.blocks.objects.OptionGroup;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface BlocksLoadOptionsResponseIF extends BaseSlackOptionsResponse {
   String TYPE = "blocks_load_options_response";
-
-  @Derived
-  default String getType() {
-    return TYPE;
-  }
 
   @JsonInclude(Include.NON_EMPTY)
   List<Option> getOptions();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlocksLoadOptionsResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlocksLoadOptionsResponseIF.java
@@ -2,6 +2,7 @@ package com.hubspot.slack.client.models.interaction;
 
 import java.util.List;
 
+import org.immutables.value.Value;
 import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 
@@ -19,6 +20,13 @@ import com.hubspot.slack.client.models.blocks.objects.OptionGroup;
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 public interface BlocksLoadOptionsResponseIF extends BaseSlackOptionsResponse {
+  String TYPE = "blocks_load_options_response";
+
+  @Value.Derived
+  default String getType() {
+    return TYPE;
+  }
+
   @JsonInclude(Include.NON_EMPTY)
   List<Option> getOptions();
 

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlocksLoadOptionsResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlocksLoadOptionsResponseIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.models.interaction;
 
 import java.util.List;
 
-import org.immutables.value.Value;
+import org.immutables.value.Value.Derived;
 import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 
@@ -22,7 +22,7 @@ import com.hubspot.slack.client.models.blocks.objects.OptionGroup;
 public interface BlocksLoadOptionsResponseIF extends BaseSlackOptionsResponse {
   String TYPE = "blocks_load_options_response";
 
-  @Value.Derived
+  @Derived
   default String getType() {
     return TYPE;
   }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/SlackOptionsResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/SlackOptionsResponseIF.java
@@ -30,11 +30,6 @@ public interface SlackOptionsResponseIF extends BaseSlackOptionsResponse {
   // NOTE: slack annoyingly has a different model for dialog options and attachment options
   // https://api.slack.com/dialogs | https://api.slack.com/docs/message-menus
 
-  @Derived
-  default String getType() {
-    return TYPE;
-  }
-
   static SlackOptionsResponse emptyAttachmentOptions() {
     return SlackOptionsResponse
         .builder()

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/SlackOptionsResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/SlackOptionsResponseIF.java
@@ -1,0 +1,97 @@
+package com.hubspot.slack.client.models.interaction;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
+
+import org.immutables.value.Value.Derived;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.BaseSlackOptionsResponse;
+import com.hubspot.slack.client.models.actions.Option;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackFormOption;
+import com.hubspot.slack.client.models.dialog.form.elements.SlackFormOptionGroup;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+@JsonInclude(Include.NON_NULL)
+public interface SlackOptionsResponseIF extends BaseSlackOptionsResponse {
+  String TYPE = "slack_options_response";
+
+  // NOTE: slack annoyingly has a different model for dialog options and attachment options
+  // https://api.slack.com/dialogs | https://api.slack.com/docs/message-menus
+
+  @Derived
+  default String getType() {
+    return TYPE;
+  }
+
+  static SlackOptionsResponse emptyAttachmentOptions() {
+    return SlackOptionsResponse
+        .builder()
+        .setAttachmentOptions(Collections.emptyList())
+        .build();
+  }
+
+  static SlackOptionsResponse ofAttachmentOptions(List<Option> options) {
+    return SlackOptionsResponse.builder().setAttachmentOptions(options).build();
+  }
+
+  static SlackOptionsResponse emptyDialogOptions() {
+    return SlackOptionsResponse
+        .builder()
+        .setDialogOptions(Collections.emptyList())
+        .build();
+  }
+
+  static SlackOptionsResponse ofDialogOptions(
+      List<SlackFormOption> dialogOptions
+  ) {
+    return SlackOptionsResponse.builder().setDialogOptions(dialogOptions).build();
+  }
+
+  static SlackOptionsResponse emptyDialogOptionGroups() {
+    return SlackOptionsResponse
+        .builder()
+        .setDialogOptionGroups(Collections.emptyList())
+        .build();
+  }
+
+  static SlackOptionsResponse ofDialogOptionGroups(
+      List<SlackFormOptionGroup> optionGroups
+  ) {
+    return SlackOptionsResponse.builder().setDialogOptionGroups(optionGroups).build();
+  }
+
+  Optional<List<Option>> getAttachmentOptions();
+
+  // attachment option groups aren't yet supported in the slack-client
+
+  Optional<List<SlackFormOption>> getDialogOptions();
+
+  Optional<List<SlackFormOptionGroup>> getDialogOptionGroups();
+
+  @Derived
+  @Nullable
+   default Object getOptions() {
+    return Stream.of(getAttachmentOptions(), getDialogOptions())
+        .findFirst()
+        .orElse(null)
+        .orElse(null);
+  }
+
+  @Derived
+  @Nullable
+  default Object getOptionGroups() {
+    return getDialogOptionGroups().orElse(null);
+  }
+}


### PR DESCRIPTION
SlackOptionsResponse model is needed to load Options to [Selects](https://api.slack.com/dialogs#select_elements) on [Slack Dialogs](https://api.slack.com/dialogs).