### PR TITLE
Fix Options retrieving in SlackOptionsResponseIF model

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/SlackOptionsResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/SlackOptionsResponseIF.java
@@ -3,7 +3,6 @@ package com.hubspot.slack.client.models.interaction;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -77,11 +76,13 @@ public interface SlackOptionsResponseIF extends BaseSlackOptionsResponse {
 
   @Derived
   @Nullable
-   default Object getOptions() {
-    return Stream.of(getAttachmentOptions(), getDialogOptions())
-        .findFirst()
-        .orElse(null)
-        .orElse(null);
+  default Object getOptions() {
+    if(getAttachmentOptions().isPresent()) {
+      return getAttachmentOptions().get();
+    } else if (getDialogOptions().isPresent()) {
+      return getDialogOptions().get();
+    }
+    return null;
   }
 
   @Derived


### PR DESCRIPTION
The logic of retrieving of handling Options in the Options response model is broken. It always returns null if attachment options are not set even if there are dialog options. This PR fixes this issue.