### PR TITLE
Make `state` in `block_actions` payload optional

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlockActionsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlockActionsIF.java
@@ -26,7 +26,7 @@ public interface BlockActionsIF extends SlackInteractiveCallback {
   @JsonProperty("actions")
   List<BlockElementAction> getElementActions();
 
-  StateValuesPayload getState();
+  Optional<StateValuesPayload> getState();
 
   @Override
   default String getCallbackId() {

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/interaction/BlockActionsSerializationTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/interaction/BlockActionsSerializationTest.java
@@ -13,4 +13,8 @@ public class BlockActionsSerializationTest extends SerializationTestBase {
     testSerialization("block_actions.json", BlockActions.class);
   }
 
+  @Test
+  public void testBlockSerializationWithoutState() throws IOException {
+    testSerialization("block_actions_without_state.json", BlockActions.class);
+  }
 }

--- a/slack-base/src/test/resources/block_actions_without_state.json
+++ b/slack-base/src/test/resources/block_actions_without_state.json
@@ -1,0 +1,79 @@
+{
+  "type": "block_actions",
+  "team": {
+    "id": "TEAM_ID",
+    "name": "TEAM_NAME",
+    "domain": "slackhubspoti-et16299"
+  },
+  "user": {
+    "id": "USER_ID",
+    "name": "auser",
+    "access_token": "xoxp-507412329303-981238771351-1412370955013-fce9dc6b782f54549b5b2d435afe229e"
+  },
+  "token": "ITS_A_SECRET",
+  "trigger_id": "869524640327.819832772087.67c795e952f7b500a9cd55d2d1830d6c",
+  "view": {
+    "id": "VRH64BLSY",
+    "team_id": "TEAM_ID",
+    "type": "modal",
+    "blocks": [
+      {
+        "type": "section",
+        "block_id": "GFS",
+        "text": {
+          "type": "mrkdwn",
+          "text": "Thanks for clicking on _something_!",
+          "verbatim": false
+        },
+        "accessory": {
+          "type": "datepicker",
+          "action_id": "my-date-picker"
+        }
+      }
+    ],
+    "private_metadata": "",
+    "callback_id": "",
+    "state": {
+      "values": {
+        "state-action": {
+          "action-value-1": {
+            "type": "text",
+            "value": "this is a text value"
+          },
+          "action-value-2": {
+            "type": "radio_buttons",
+            "selected_option": null
+          },
+          "action-value-3": {
+            "type": "external_select",
+            "selected_option": null
+          },
+          "action-value-4": {
+            "type": "datepicker",
+            "selected_date": "2020-11-03"
+          }
+        }
+      }
+    },
+    "hash": "1576003032.b99e0143",
+    "title": {
+      "type": "plain_text",
+      "text": "Hi auser",
+      "emoji": true
+    },
+    "clear_on_close": false,
+    "notify_on_close": false,
+    "root_view_id": "VRH64BLSY",
+    "app_id": "APP_ID",
+    "external_id": "",
+    "bot_id": "COOL_BOT_ID"
+  },
+  "actions": [
+    {
+      "type": "datepicker",
+      "action_id": "my-date-picker",
+      "block_id": "GFS",
+      "action_ts": "1576003038.785719"
+    }
+  ]
+}


### PR DESCRIPTION
As per [Slack documentation](https://api.slack.com/reference/interaction-payloads/block-actions#fields) it sends either `state.values` or `view.state.values` so both of these fields should be `Optional` so we don't fail do parse the payload if one of them is missing.

`view.state.values` is sent on interactions with blocks inside of modal. 
`state.values` is sent on the interactions with blocks inside of the message.