### PR TITLE
Change time picker initial time format

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/TimePickerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/TimePickerIF.java
@@ -30,7 +30,7 @@ public interface TimePickerIF extends BlockElement, HasActionId {
 
   Optional<Text> getPlaceholder();
 
-  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "H:mm")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
   Optional<LocalTime> getInitialTime();
 
   @JsonProperty("confirm")


### PR DESCRIPTION
Slack required set initial time in HH:mm format.
In this PR we change the initial time format to HH:mm