### PR TITLE
Fix DateTimeParseException when data field is null

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/views/json/StateActionValueDeserializer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/views/json/StateActionValueDeserializer.java
@@ -12,6 +12,9 @@ import java.io.IOException;
 import java.time.LocalDate;
 
 public class StateActionValueDeserializer extends StdDeserializer<StateActionValue> {
+  private static final String BLOCK_ELEMENT_TYPE = "type";
+  private static final String BLOCK_ELEMENT_VALUE = "value";
+  private static final String SELECTED_OPTION = "selected_option";
   private static final String DATE_FIELD = "selected_date";
 
   protected StateActionValueDeserializer() {
@@ -25,20 +28,22 @@ public class StateActionValueDeserializer extends StdDeserializer<StateActionVal
     ObjectCodec codec = p.getCodec();
     JsonNode node = codec.readTree(p);
 
-    if (node.has("type")) {
-      builder.setBlockElementType(node.get("type").asText());
+    if (node.has(BLOCK_ELEMENT_TYPE)) {
+      builder.setBlockElementType(node.get(BLOCK_ELEMENT_TYPE).asText());
     }
 
-    if (node.has("value")) {
-      builder.setBlockElementValue(node.get("value").asText());
-    } else if (node.has("selected_option")) {
-      final JsonNode selectedOption = node.get("selected_option");
+    if (node.has(BLOCK_ELEMENT_VALUE)) {
+      builder.setBlockElementValue(node.get(BLOCK_ELEMENT_VALUE).asText());
+    } else if (node.has(SELECTED_OPTION)) {
+      final JsonNode selectedOption = node.get(SELECTED_OPTION);
       final Option option = codec.treeToValue(selectedOption, Option.class);
       if (option != null) {
         builder.setBlockElementValue(option);
       }
-    } else if (node.has("selected_date")) {
-      builder.setBlockElementValue(LocalDate.parse(node.get("selected_date").asText()));
+    } else if (node.has(DATE_FIELD)) {
+      if (!node.get(DATE_FIELD).isNull()) {
+        builder.setBlockElementValue(LocalDate.parse(node.get(DATE_FIELD).asText()));
+      }
     }
 
     return builder.build();


### PR DESCRIPTION
There are throws `DateTimeParseException` when trying to deserialize slack action with null initial date from the date picker.
In this PR we skip deserializing the date field with null initial values.