### PR TITLE
Sh/add request verification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <module>slack-java-client</module>
     <module>slack-java-client-examples</module>
     <module>slack-java-client-guice</module>
+    <module>slack-request-verifier</module>
   </modules>
 
   <properties>
@@ -41,6 +42,11 @@
       <dependency>
         <groupId>com.hubspot.slack</groupId>
         <artifactId>slack-java-client-examples</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.hubspot.slack</groupId>
+        <artifactId>slack-request-verifier</artifactId>
         <version>${project.version}</version>
       </dependency>
 

--- a/slack-java-client-guice/pom.xml
+++ b/slack-java-client-guice/pom.xml
@@ -20,6 +20,10 @@
       <artifactId>slack-java-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.hubspot.slack</groupId>
+      <artifactId>slack-request-verifier</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/slack-java-client-guice/src/main/java/com/hubspot/slack/client/guice/SlackClientModule.java
+++ b/slack-java-client-guice/src/main/java/com/hubspot/slack/client/guice/SlackClientModule.java
@@ -1,12 +1,14 @@
 package com.hubspot.slack.client.guice;
 
 import com.google.inject.AbstractModule;
+import com.hubspot.slack.client.request.verifier.SlackRequestVerifierModule;
 
 public class SlackClientModule extends AbstractModule {
 
   @Override
   protected void configure() {
     install(new com.hubspot.slack.client.SlackClientModule());
+    install(new SlackRequestVerifierModule());
   }
 
   @Override

--- a/slack-request-verifier/pom.xml
+++ b/slack-request-verifier/pom.xml
@@ -35,22 +35,16 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.24.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
-      <version>2.24.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/slack-request-verifier/pom.xml
+++ b/slack-request-verifier/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.hubspot.slack</groupId>
+    <artifactId>slack-client</artifactId>
+    <version>1.13-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>slack-request-verifier</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-assistedinject</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.24.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>2.24.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/slack-request-verifier/src/main/java/com/hubspot/slack/client/request/verifier/SlackRequestVerifierFilter.java
+++ b/slack-request-verifier/src/main/java/com/hubspot/slack/client/request/verifier/SlackRequestVerifierFilter.java
@@ -1,0 +1,151 @@
+package com.hubspot.slack.client.request.verifier;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.List;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+
+import org.apache.commons.codec.binary.Hex;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Preconditions;
+import com.google.common.hash.Hashing;
+import com.google.common.io.CharStreams;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+/**
+ * Check for detailed information https://api.slack.com/authentication/verifying-requests-from-slack
+ */
+public class SlackRequestVerifierFilter implements ContainerRequestFilter {
+
+  private static final String SLACK_TIMESTAMP_HEADER = "X-Slack-Request-Timestamp";
+  private static final String SLACK_SIGNATURE_HEADER = "X-Slack-Signature";
+  private static final String CONCATENATED_SIGN_TEMPLATE = "%s:%s:%s";
+  private static final String ENCODED_SIGNATURE_TEMPLATE = "%s=%s";
+  private static final String VERSION_NUMBER = "v0";
+
+  private final long requestExpirationTime;
+  private final String signingSecret;
+
+  public interface Factory {
+    SlackRequestVerifierFilter create(
+        @Assisted("requestExpirationTime") long requestExpirationTime,
+        @Assisted("signingSecret") String signingSecret
+    );
+  }
+
+  @Inject
+  protected SlackRequestVerifierFilter(
+      @Assisted("requestExpirationTime") long requestExpirationTime,
+      @Assisted("signingSecret") String signingSecret
+  ) {
+    this.requestExpirationTime = requestExpirationTime;
+    this.signingSecret = signingSecret;
+  }
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) {
+    List<String> slackTimestampHeaders = requestContext
+        .getHeaders()
+        .get(SLACK_TIMESTAMP_HEADER);
+    List<String> slackSignatureHeaders = requestContext
+        .getHeaders()
+        .get(SLACK_SIGNATURE_HEADER);
+
+    Preconditions.checkNotNull(
+        slackTimestampHeaders,
+        "Missing header " + SLACK_TIMESTAMP_HEADER
+    );
+    Preconditions.checkNotNull(
+        slackSignatureHeaders,
+        "Missing header " + SLACK_SIGNATURE_HEADER
+    );
+
+    Preconditions.checkArgument(
+        slackTimestampHeaders.size() == 1,
+        "Expected single header " + SLACK_TIMESTAMP_HEADER
+    );
+    Preconditions.checkArgument(
+        slackSignatureHeaders.size() == 1,
+        "Expected single header " + SLACK_SIGNATURE_HEADER
+    );
+
+    validateRequest(
+        getRequestBody(requestContext),
+        slackTimestampHeaders.get(0),
+        slackSignatureHeaders.get(0)
+    );
+  }
+
+  private String getRequestBody(ContainerRequestContext requestContext) {
+    try (InputStream inputStream = requestContext.getEntityStream()) {
+      String body = CharStreams.toString(
+          new InputStreamReader(inputStream, Charsets.UTF_8)
+      );
+
+      if (inputStream instanceof ByteArrayInputStream) {
+        inputStream.reset();
+      } else {
+        requestContext.setEntityStream(new ByteArrayInputStream(body.getBytes(Charsets.UTF_8)));
+      }
+
+      return body;
+    } catch (IOException exception) {
+      throw new RuntimeException(
+          String.format(
+              "Encountered exception reading bytes from body of request %s",
+              requestContext
+          ),
+          exception
+      );
+    }
+  }
+
+  private void validateRequest(
+      String body,
+      String slackTimestampHeader,
+      String slackSignatureHeader
+  ) {
+    checkRequestExpired(Long.valueOf(slackTimestampHeader));
+    checkRequestSignature(body, slackTimestampHeader, slackSignatureHeader);
+  }
+
+  private void checkRequestExpired(Long requestTimestamp) {
+    Preconditions.checkArgument(
+        ((System.currentTimeMillis() / 1000) - requestTimestamp) < requestExpirationTime,
+        "Request has expired"
+    );
+  }
+
+  private void checkRequestSignature(
+      String body,
+      String slackTimestampHeader,
+      String slackSignatureHeader
+  ) {
+    String concatenatedSignature = String.format(CONCATENATED_SIGN_TEMPLATE, VERSION_NUMBER, slackTimestampHeader, body);
+    String encodedSignature = String.format(
+        ENCODED_SIGNATURE_TEMPLATE,
+        VERSION_NUMBER,
+        getEncodedSignature(concatenatedSignature)
+    );
+
+    Preconditions.checkArgument(
+        encodedSignature.equals(slackSignatureHeader),
+        "Invalid signature"
+    );
+  }
+
+  private String getEncodedSignature(String signature) {
+    return Hex.encodeHexString(
+        Hashing
+            .hmacSha256(signingSecret.getBytes(Charsets.UTF_8))
+            .hashString(signature, Charsets.UTF_8)
+            .asBytes()
+    );
+  }
+}

--- a/slack-request-verifier/src/main/java/com/hubspot/slack/client/request/verifier/SlackRequestVerifierModule.java
+++ b/slack-request-verifier/src/main/java/com/hubspot/slack/client/request/verifier/SlackRequestVerifierModule.java
@@ -1,0 +1,22 @@
+package com.hubspot.slack.client.request.verifier;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+
+public class SlackRequestVerifierModule extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    install(new FactoryModuleBuilder().build(SlackRequestVerifierFilter.Factory.class));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return o != null && getClass().equals(o.getClass());
+  }
+
+  @Override
+  public int hashCode() {
+    return getClass().hashCode();
+  }
+}

--- a/slack-request-verifier/src/main/test/com.hubspot.slack.client.request.verifier/SlackRequestVerifierFilterTest.java
+++ b/slack-request-verifier/src/main/test/com.hubspot.slack.client.request.verifier/SlackRequestVerifierFilterTest.java
@@ -1,0 +1,176 @@
+package com.hubspot.slack.client.request.verifier;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+@ExtendWith(MockitoExtension.class)
+public class SlackRequestVerifierFilterTest {
+
+  private static final String SIGNING_SECRET = "secret";
+  private static final long REQUEST_EXPIRATION_TIME = 1;
+  private static final String SIGNATURE = "v0=1a7f6461d46b08d647f4992b34d9264768a3f905e61ef596d733f55673691427";
+  private static final String SLACK_TIMESTAMP_HEADER = "X-Slack-Request-Timestamp";
+  private static final String SLACK_SIGNATURE_HEADER = "X-Slack-Signature";
+  private static final String HEADER_EMPTY_ERROR_TEMPLATE = "Missing header %s";
+  private static final String EXPECTED_SINGLE_HEADER_ERROR_TEMPLATE = "Expected single header %s";
+  private static final String GET_REQUEST_BODY_ERROR_TEMPLATE = "Encountered exception reading bytes from body of request %s";
+  private static final String REQUEST_EXPIRED_ERROR = "Request has expired";
+  private static final String INVALID_SIGNATURE_ERROR = "Invalid signature";
+
+  private SlackRequestVerifierFilter slackRequestVerifierFilter;
+
+  @BeforeEach
+  void setup() {
+    this.slackRequestVerifierFilter = new SlackRequestVerifierFilter(REQUEST_EXPIRATION_TIME, SIGNING_SECRET);
+  }
+
+  @Test
+  public void itFailsBecauseOfEmptyTimestampHeader() {
+    ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+    when(requestContext.getHeaders())
+        .thenReturn(getEmptyMap());
+
+    assertThatThrownBy(() -> slackRequestVerifierFilter.filter(requestContext))
+        .as("Filter fails when timestamp header is empty")
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage(String.format(HEADER_EMPTY_ERROR_TEMPLATE, SLACK_TIMESTAMP_HEADER));
+  }
+
+  @Test
+  public void itFailsBecauseOfEmptySignatureHeader() {
+    ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+    when(requestContext.getHeaders())
+        .thenReturn(getMapWithTimestampHeader());
+
+    assertThatThrownBy(() -> slackRequestVerifierFilter.filter(requestContext))
+        .as("Filter fails when signature header is empty")
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage(String.format(HEADER_EMPTY_ERROR_TEMPLATE, SLACK_SIGNATURE_HEADER));
+  }
+
+  @Test
+  public void itFailsBecauseOfMultipleTimestampHeaderValue() {
+    ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+    when(requestContext.getHeaders())
+        .thenReturn(getMapHeaders(getList(1L, 2L), getList("signature")));
+
+    assertThatThrownBy(() -> slackRequestVerifierFilter.filter(requestContext))
+        .as("Filter fails when there are more than one timestamp header present")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(String.format(EXPECTED_SINGLE_HEADER_ERROR_TEMPLATE, SLACK_TIMESTAMP_HEADER));
+  }
+
+  @Test
+  public void itFailsBecauseOfMultipleSignatureHeaderValue() {
+    ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+    when(requestContext.getHeaders())
+        .thenReturn(getMapHeaders(getList(1L), getList("signature", "second signature")));
+
+    assertThatThrownBy(() -> slackRequestVerifierFilter.filter(requestContext))
+        .as("Filter fails when there are more than one signature header present")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(String.format(EXPECTED_SINGLE_HEADER_ERROR_TEMPLATE, SLACK_SIGNATURE_HEADER));
+  }
+
+  @Test
+  public void itFailsWhileGettingResponseBody() {
+    ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+    ByteArrayInputStream inputStream = mock(ByteArrayInputStream.class);
+
+    when(requestContext.getHeaders())
+        .thenReturn(getMapHeaders(getList(1L), getList("signature")));
+    when(requestContext.getEntityStream())
+        .thenReturn(inputStream);
+
+    assertThatThrownBy(() -> slackRequestVerifierFilter.filter(requestContext))
+        .as("Filter fails while getting response body")
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage(String.format(GET_REQUEST_BODY_ERROR_TEMPLATE, requestContext));
+  }
+
+  @Test
+  public void itFailsWhenRequestExpires() {
+    ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+    InputStream inputStream = new ByteArrayInputStream("request body".getBytes(StandardCharsets.UTF_8));
+
+    when(requestContext.getHeaders())
+        .thenReturn(getMapHeaders(getList(1L), getList("signature")));
+    when(requestContext.getEntityStream())
+        .thenReturn(inputStream);
+
+    assertThatThrownBy(() -> slackRequestVerifierFilter.filter(requestContext))
+        .as("Filter fails while request has expired")
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage(REQUEST_EXPIRED_ERROR);
+  }
+
+  @Test
+  public void itFailsWhenSignatureInvalid() {
+    ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+    InputStream inputStream = new ByteArrayInputStream("request body".getBytes(StandardCharsets.UTF_8));
+
+    when(requestContext.getHeaders())
+        .thenReturn(getMapHeaders(getList(System.currentTimeMillis()), getList("signature")));
+    when(requestContext.getEntityStream())
+        .thenReturn(inputStream);
+
+    assertThatThrownBy(() -> slackRequestVerifierFilter.filter(requestContext))
+        .as("Filter fails when signature invalid")
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage(INVALID_SIGNATURE_ERROR);
+  }
+
+  @Test
+  public void itFilterSuccessfully() {
+    ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+    InputStream inputStream = new ByteArrayInputStream("request body".getBytes(StandardCharsets.UTF_8));
+
+    when(requestContext.getHeaders())
+        .thenReturn(getMapHeaders(getList(System.currentTimeMillis()), getList(SIGNATURE)));
+    when(requestContext.getEntityStream())
+        .thenReturn(inputStream);
+
+    assertThatThrownBy(() -> slackRequestVerifierFilter.filter(requestContext))
+        .as("Filter fails when signature invalid")
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage(INVALID_SIGNATURE_ERROR);
+  }
+
+  private MultivaluedMap<String, String> getEmptyMap() {
+    return new MultivaluedHashMap<>();
+  }
+
+  private MultivaluedMap<String, String> getMapWithTimestampHeader() {
+    MultivaluedMap<String, String> result = new MultivaluedHashMap<>();
+    result.put(SLACK_TIMESTAMP_HEADER, getList("1"));
+    return result;
+  }
+
+  private MultivaluedMap<String, String> getMapHeaders(List<Long> timestampHeaders, List<String> signatures) {
+    MultivaluedMap<String, String> result = new MultivaluedHashMap<>();
+    result.put(SLACK_TIMESTAMP_HEADER, timestampHeaders.stream().map(longValue -> Long.toString(longValue)).collect(Collectors.toList()));
+    result.put(SLACK_SIGNATURE_HEADER, signatures);
+    return result;
+  }
+
+  private <T> List<T> getList(T... data) {
+    return Stream.of(data).collect(Collectors.toList());
+  }
+}

--- a/slack-request-verifier/src/test/java/com.hubspot.slack.client.request.verifier/SlackRequestVerifierFilterTest.java
+++ b/slack-request-verifier/src/test/java/com.hubspot.slack.client.request.verifier/SlackRequestVerifierFilterTest.java
@@ -14,13 +14,9 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.Before;
+import org.junit.Test;
 
-
-@ExtendWith(MockitoExtension.class)
 public class SlackRequestVerifierFilterTest {
 
   private static final String SIGNING_SECRET = "secret";
@@ -36,8 +32,8 @@ public class SlackRequestVerifierFilterTest {
 
   private SlackRequestVerifierFilter slackRequestVerifierFilter;
 
-  @BeforeEach
-  void setup() {
+  @Before
+  public void setup() {
     this.slackRequestVerifierFilter = new SlackRequestVerifierFilter(REQUEST_EXPIRATION_TIME, SIGNING_SECRET);
   }
 


### PR DESCRIPTION
### Description
Slack supports request verification mechanisms that are already used in a few projects so it's better to move the logic to this project and then use it wherever is needed. [Slack documentation](https://api.slack.com/authentication/verifying-requests-from-slack)

### Solution
To provide this logic I have done:
- added `slack-request-verifier` module
- added `SlackRequestVerifierFilter` class
- added unit tests to this class
