### PR TITLE
add SlackRequestVerifier annotation

### DIFF
--- a/slack-request-verifier/src/main/java/com/hubspot/slack/client/request/verifier/SlackRequestVerifier.java
+++ b/slack-request-verifier/src/main/java/com/hubspot/slack/client/request/verifier/SlackRequestVerifier.java
@@ -1,0 +1,11 @@
+package com.hubspot.slack.client.request.verifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import com.google.inject.BindingAnnotation;
+
+@BindingAnnotation
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SlackRequestVerifier {
+}

--- a/slack-request-verifier/src/main/java/com/hubspot/slack/client/request/verifier/VerifySlackRequest.java
+++ b/slack-request-verifier/src/main/java/com/hubspot/slack/client/request/verifier/VerifySlackRequest.java
@@ -7,5 +7,5 @@ import com.google.inject.BindingAnnotation;
 
 @BindingAnnotation
 @Retention(RetentionPolicy.RUNTIME)
-public @interface SlackRequestVerifier {
+public @interface VerifySlackRequest {
 }


### PR DESCRIPTION
One of the two ways to implement a slack request verifier needs an annotation over the resource method and class that extends `SlackRequestVerifierFilter`, to prevent duplication of the annotations it's better to add this annotation to this project