### PR TITLE
DO NOT MERGE/REVIEW. Add shared channels filtering.

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationsListParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationsListParamsIF.java
@@ -14,4 +14,5 @@ import com.hubspot.immutables.style.HubSpotStyle;
 public interface ConversationsListParamsIF extends BaseConversationsFilter {
   Optional<String> getCursor();
   Optional<Integer> getLimit();
+  Optional<Boolean> shouldExcludeSharedChannels();
 }


### PR DESCRIPTION
In this PR we add filtering logic to filter out shared channels, in case when ConversationsListParams.shouldExcludeSharedChannels() is true.