### PR TITLE
Add `isShared` field to `SlackChannel`.

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/SlackChannelIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/SlackChannelIF.java
@@ -20,6 +20,7 @@ public interface SlackChannelIF {
   Optional<Boolean> getIsGeneral();
   Optional<Boolean> getIsPrivate();
   Optional<Boolean> getIsMember();
+  Optional<Boolean> getIsShared();
 
   @Derived
   @JsonIgnore


### PR DESCRIPTION
The field is added so that all channels stored in the cache could have `isShared` field, which will allow us to do filtering out shared channels, no matter if they are fetched from API or cache.