### PR TITLE
Add message blocks.

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/Block.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/Block.java
@@ -6,6 +6,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.hubspot.slack.client.models.BlockOrAttachment;
+import com.hubspot.slack.client.models.blocks.messages.Link;
+import com.hubspot.slack.client.models.blocks.messages.RichText;
+import com.hubspot.slack.client.models.blocks.messages.RichTextList;
+import com.hubspot.slack.client.models.blocks.messages.RichTextPreformatted;
+import com.hubspot.slack.client.models.blocks.messages.RichTextQuote;
+import com.hubspot.slack.client.models.blocks.messages.RichTextSection;
+import com.hubspot.slack.client.models.blocks.messages.Text;
+import com.hubspot.slack.client.models.blocks.messages.User;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = UnknownBlock.class)
 @JsonSubTypes({
@@ -17,6 +25,14 @@ import com.hubspot.slack.client.models.BlockOrAttachment;
     @JsonSubTypes.Type(value = Input.class, name = Input.TYPE),
     @JsonSubTypes.Type(value = Section.class, name = Section.TYPE),
     @JsonSubTypes.Type(value = Header.class, name = Header.TYPE),
+    @JsonSubTypes.Type(value = Text.class, name = Text.TYPE),
+    @JsonSubTypes.Type(value = Link.class, name = Link.TYPE),
+    @JsonSubTypes.Type(value = User.class, name = User.TYPE),
+    @JsonSubTypes.Type(value = RichText.class, name = RichText.TYPE),
+    @JsonSubTypes.Type(value = RichTextSection.class, name = RichTextSection.TYPE),
+    @JsonSubTypes.Type(value = RichTextList.class, name = RichTextList.TYPE),
+    @JsonSubTypes.Type(value = RichTextQuote.class, name = RichTextQuote.TYPE),
+    @JsonSubTypes.Type(value = RichTextPreformatted.class, name = RichTextPreformatted.TYPE)
 })
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface Block extends BlockOrAttachment {

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/LinkIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/LinkIF.java
@@ -1,0 +1,23 @@
+package com.hubspot.slack.client.models.blocks.messages;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public interface LinkIF extends MessageBlock{
+    String TYPE = "link";
+
+    @Override
+    @Value.Derived
+    default String getType() {
+        return TYPE;
+    }
+
+    String getUrl();
+
+    String getText();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/MessageBlock.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/MessageBlock.java
@@ -1,0 +1,20 @@
+package com.hubspot.slack.client.models.blocks.messages;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.hubspot.slack.client.models.blocks.Block;
+//import com.fasterxml.jackson.annotation.JsonSubTypes;
+//import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+//@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+//@JsonSubTypes({
+//        @JsonSubTypes.Type(value = Text.class, name = Text.TYPE),
+//        @JsonSubTypes.Type(value = Link.class, name = Link.TYPE),
+//        @JsonSubTypes.Type(value = RichText.class, name = RichText.TYPE),
+//        @JsonSubTypes.Type(value = RichTextSection.class, name = RichTextSection.TYPE),
+//        @JsonSubTypes.Type(value = RichTextList.class, name = RichTextList.TYPE),
+//        @JsonSubTypes.Type(value = RichTextQuote.class, name = RichTextQuote.TYPE),
+//        @JsonSubTypes.Type(value = RichTextPreformatted.class, name = RichTextPreformatted.TYPE)
+//})
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public interface MessageBlock extends Block {
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/MessageBlock.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/MessageBlock.java
@@ -2,19 +2,7 @@ package com.hubspot.slack.client.models.blocks.messages;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.hubspot.slack.client.models.blocks.Block;
-//import com.fasterxml.jackson.annotation.JsonSubTypes;
-//import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-//@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-//@JsonSubTypes({
-//        @JsonSubTypes.Type(value = Text.class, name = Text.TYPE),
-//        @JsonSubTypes.Type(value = Link.class, name = Link.TYPE),
-//        @JsonSubTypes.Type(value = RichText.class, name = RichText.TYPE),
-//        @JsonSubTypes.Type(value = RichTextSection.class, name = RichTextSection.TYPE),
-//        @JsonSubTypes.Type(value = RichTextList.class, name = RichTextList.TYPE),
-//        @JsonSubTypes.Type(value = RichTextQuote.class, name = RichTextQuote.TYPE),
-//        @JsonSubTypes.Type(value = RichTextPreformatted.class, name = RichTextPreformatted.TYPE)
-//})
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface MessageBlock extends Block {
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/RichBlockStyle.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/RichBlockStyle.java
@@ -1,0 +1,14 @@
+package com.hubspot.slack.client.models.blocks.messages;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum RichBlockStyle {
+    ORDERED,
+    BULLET;
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return name().toLowerCase();
+    }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/RichMessageBlock.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/RichMessageBlock.java
@@ -1,0 +1,7 @@
+package com.hubspot.slack.client.models.blocks.messages;
+
+import java.util.List;
+
+public interface RichMessageBlock extends MessageBlock{
+    List<MessageBlock> getElements();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/RichTextIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/RichTextIF.java
@@ -1,0 +1,20 @@
+package com.hubspot.slack.client.models.blocks.messages;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
+
+
+@Value.Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public interface RichTextIF extends RichMessageBlock{
+    String TYPE = "rich_text";
+
+    @Override
+    @Value.Derived
+    default String getType() {
+        return TYPE;
+    }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/RichTextListIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/RichTextListIF.java
@@ -1,0 +1,24 @@
+package com.hubspot.slack.client.models.blocks.messages;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public interface RichTextListIF extends RichMessageBlock {
+    String TYPE = "rich_text_list";
+    @Override
+    @Value.Derived
+    default String getType() {
+        return TYPE;
+    }
+
+    RichBlockStyle getStyle();
+
+    int getIndent();
+
+    int getBorder();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/RichTextPreformattedIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/RichTextPreformattedIF.java
@@ -1,0 +1,19 @@
+package com.hubspot.slack.client.models.blocks.messages;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public interface RichTextPreformattedIF extends RichMessageBlock{
+    String TYPE = "rich_text_preformatted";
+
+    @Override
+    @Value.Derived
+    default String getType() {
+        return TYPE;
+    }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/RichTextQuoteIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/RichTextQuoteIF.java
@@ -1,0 +1,19 @@
+package com.hubspot.slack.client.models.blocks.messages;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public interface RichTextQuoteIF extends RichMessageBlock{
+    String TYPE = "rich_text_quote";
+
+    @Override
+    @Value.Derived
+    default String getType() {
+        return TYPE;
+    }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/RichTextSectionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/RichTextSectionIF.java
@@ -1,0 +1,18 @@
+package com.hubspot.slack.client.models.blocks.messages;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public interface RichTextSectionIF extends RichMessageBlock {
+    String TYPE = "rich_text_section";
+    @Override
+    @Value.Derived
+    default String getType() {
+        return TYPE;
+    }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/TextIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/TextIF.java
@@ -1,0 +1,25 @@
+package com.hubspot.slack.client.models.blocks.messages;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
+
+import java.util.Optional;
+
+@Value.Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public interface TextIF extends MessageBlock{
+    String TYPE = "text";
+
+    @Override
+    @Value.Derived
+    default String getType() {
+        return TYPE;
+    }
+
+    String getText();
+
+    Optional<TextStyle> getStyle();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/TextStyleIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/TextStyleIF.java
@@ -1,0 +1,18 @@
+package com.hubspot.slack.client.models.blocks.messages;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
+
+import java.util.Optional;
+
+@Value.Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public interface TextStyleIF {
+    Optional<Boolean> isBold();
+    Optional<Boolean> isItalic();
+    Optional<Boolean> isStrike();
+    Optional<Boolean> isCode();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/UserIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/UserIF.java
@@ -1,0 +1,21 @@
+package com.hubspot.slack.client.models.blocks.messages;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public interface UserIF extends MessageBlock{
+    String TYPE = "user";
+
+    @Override
+    @Value.Derived
+    default String getType() {
+        return TYPE;
+    }
+
+    String getUserId();
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/blocks/messages/MessageActionSerializationTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/blocks/messages/MessageActionSerializationTest.java
@@ -1,0 +1,34 @@
+package com.hubspot.slack.client.models.blocks.messages;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubspot.slack.client.jackson.ObjectMapperUtils;
+import com.hubspot.slack.client.models.JsonLoader;
+import com.hubspot.slack.client.models.LiteMessage;
+import com.hubspot.slack.client.models.blocks.Block;
+import com.hubspot.slack.client.models.interaction.MessageAction;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+public class MessageActionSerializationTest {
+    public static final int BLOCKS_COUNT = 1;
+    private static final int RICH_MESSAGE_BLOCKS_COUNT = 18;
+
+    @Test
+    public void testMessageActionSerialization() throws IOException {
+        String rawJson = JsonLoader.loadJsonFromFile("message_action.json");
+        MessageAction messageAction = ObjectMapperUtils.mapper().readValue(rawJson, MessageAction.class);
+
+        assertThat(messageAction).isNotNull();
+
+        LiteMessage message = messageAction.getMessage();
+        List<Block> blocks = message.getBlocks();
+        assertThat(blocks.size()).isEqualTo(BLOCKS_COUNT);
+
+        RichMessageBlock firstBlock = (RichMessageBlock) blocks.get(0);
+        List<MessageBlock> elements = firstBlock.getElements();
+        assertThat(elements.size()).isEqualTo(RICH_MESSAGE_BLOCKS_COUNT);
+    }
+}

--- a/slack-base/src/test/resources/message_action.json
+++ b/slack-base/src/test/resources/message_action.json
@@ -1,0 +1,394 @@
+
+  {
+    "type": "message_action",
+    "token": "uWopedqK86MJfjUeq8v9pUAD",
+    "action_ts": "1668518741.225922",
+    "team": { "id": "T01DK9EHX5F", "domain": "nliutyi-slack-test" },
+    "user": {
+      "id": "U01DCR2RJJY",
+      "username": "liutyi.nazar",
+      "team_id": "T01DK9EHX5F",
+      "name": "liutyi.nazar"
+    },
+    "channel": { "id": "C01DK9EJ9BK", "name": "general" },
+    "is_enterprise_install": false,
+    "callback_id": "create_a_note_view_open",
+    "trigger_id": "4374030983106.1461320609185.e7f0674b7df7e1921fab448523f7b57f",
+    "response_url": "https://hooks.slack.com/app/T01DK9EHX5F/4359488714231/3UovfsZ3ac6Dfh0xdZdyhTll",
+    "message_ts": "1668518700.305859",
+    "message": {
+      "client_msg_id": "7c5a7a69-d6df-49a7-8d80-ba9756e2a032",
+      "type": "message",
+      "subtype": null,
+      "botId": null,
+      "username": null,
+      "text": "Simple case:\n*A bold text.*\n_Italic text._\n~Strike text.~\n<https://calendar.google.com/calendar/u/1/r/week|Link>\n1. Numbered list root level.\n2. Ordered list also root level\n    a. Letter list from ordered(numbered) list\n    b. Also letter list\n        i. Rome list level 1\n        ii. Rome list next item\n        iii. *Rome list bold*\n        iv. _Rome list italic_\n        v. _*Rome list italic bold*_\n        vi. ~_*Rome list italic bold strike*_~\n    c. Letter list item after rome list.\n3. Ordered-numbere list item after letter list.\n\u2022 Bulleted list root\n\u2022 Bulleted list root 2.\n    \u25e6 Bulleted list inside previous bulleted list \n    \u25e6 Bulleted list item 2 inside previous bulleted list \n        \u25aa\ufe0e Bulleted list item third incapsulated \n        \u25aa\ufe0e Bulleted list item third incapsulated 2\n            \u2022 Bulleted list level 4 of deepness\n        \u25aa\ufe0e Bulleted list item third incapsulated 3\n    \u25e6 Bulleted list item 3 inside previous bulleted list \n\u2022 Bulleted list root 3.\nJust a row after the list ( should be separated )\n> Dobrii vechir, everybady!\n`code line`\n```var bar far;\n\npub sub mob dob;\ncucu```\nThe user mentioning line: <@U01DVDVMS12>",
+      "user": "U01DCR2RJJY",
+      "ts": "1668518700.305859",
+      "blocks": [
+        {
+          "type": "rich_text",
+          "block_id": "yW=Nc",
+          "elements": [
+            {
+              "type": "rich_text_section",
+              "elements": [
+                { "type": "text", "text": "Simple case:\n" },
+                {
+                  "type": "text",
+                  "text": "A bold text.",
+                  "style": { "bold": true }
+                },
+                { "type": "text", "text": "\n" },
+                {
+                  "type": "text",
+                  "text": "Italic text.",
+                  "style": { "italic": true }
+                },
+                { "type": "text", "text": "\n" },
+                {
+                  "type": "text",
+                  "text": "Strike text.",
+                  "style": { "strike": true }
+                },
+                { "type": "text", "text": "\n" },
+                {
+                  "type": "link",
+                  "url": "https://calendar.google.com/calendar/u/1/r/week",
+                  "text": "Link"
+                },
+                { "type": "text", "text": "\n" }
+              ]
+            },
+            {
+              "type": "rich_text_list",
+              "elements": [
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    { "type": "text", "text": "Numbered list root level." }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    { "type": "text", "text": "Ordered list also root level" }
+                  ]
+                }
+              ],
+              "style": "ordered",
+              "indent": 0,
+              "border": 0
+            },
+            {
+              "type": "rich_text_list",
+              "elements": [
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Letter list from ordered(numbered) list"
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [{ "type": "text", "text": "Also letter list" }]
+                }
+              ],
+              "style": "ordered",
+              "indent": 1,
+              "border": 0
+            },
+            {
+              "type": "rich_text_list",
+              "elements": [
+                {
+                  "type": "rich_text_section",
+                  "elements": [{ "type": "text", "text": "Rome list level 1" }]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    { "type": "text", "text": "Rome list next item" }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Rome list bold",
+                      "style": { "bold": true }
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Rome list italic",
+                      "style": { "italic": true }
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Rome list italic bold",
+                      "style": { "bold": true, "italic": true }
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Rome list italic bold strike",
+                      "style": { "bold": true, "italic": true, "strike": true }
+                    }
+                  ]
+                }
+              ],
+              "style": "ordered",
+              "indent": 2,
+              "border": 0
+            },
+            {
+              "type": "rich_text_list",
+              "elements": [
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Letter list item after rome list."
+                    }
+                  ]
+                }
+              ],
+              "style": "ordered",
+              "indent": 1,
+              "offset": 2,
+              "border": 0
+            },
+            {
+              "type": "rich_text_list",
+              "elements": [
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Ordered-numbere list item after letter list."
+                    }
+                  ]
+                }
+              ],
+              "style": "ordered",
+              "indent": 0,
+              "offset": 2,
+              "border": 0
+            },
+            {
+              "type": "rich_text_list",
+              "elements": [
+                {
+                  "type": "rich_text_section",
+                  "elements": [{ "type": "text", "text": "Bulleted list root" }]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    { "type": "text", "text": "Bulleted list root 2." }
+                  ]
+                }
+              ],
+              "style": "bullet",
+              "indent": 0,
+              "border": 0
+            },
+            {
+              "type": "rich_text_list",
+              "elements": [
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Bulleted list inside previous bulleted list "
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Bulleted list item 2 inside previous bulleted list "
+                    }
+                  ]
+                }
+              ],
+              "style": "bullet",
+              "indent": 1,
+              "border": 0
+            },
+            {
+              "type": "rich_text_list",
+              "elements": [
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Bulleted list item third incapsulated "
+                    }
+                  ]
+                },
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Bulleted list item third incapsulated 2"
+                    }
+                  ]
+                }
+              ],
+              "style": "bullet",
+              "indent": 2,
+              "border": 0
+            },
+            {
+              "type": "rich_text_list",
+              "elements": [
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Bulleted list level 4 of deepness"
+                    }
+                  ]
+                }
+              ],
+              "style": "bullet",
+              "indent": 3,
+              "border": 0
+            },
+            {
+              "type": "rich_text_list",
+              "elements": [
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Bulleted list item third incapsulated 3"
+                    }
+                  ]
+                }
+              ],
+              "style": "bullet",
+              "indent": 2,
+              "border": 0
+            },
+            {
+              "type": "rich_text_list",
+              "elements": [
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "Bulleted list item 3 inside previous bulleted list "
+                    }
+                  ]
+                }
+              ],
+              "style": "bullet",
+              "indent": 1,
+              "border": 0
+            },
+            {
+              "type": "rich_text_list",
+              "elements": [
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    { "type": "text", "text": "Bulleted list root 3." }
+                  ]
+                }
+              ],
+              "style": "bullet",
+              "indent": 0,
+              "border": 0
+            },
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "text",
+                  "text": "Just a row after the list ( should be separated )\n"
+                }
+              ]
+            },
+            {
+              "type": "rich_text_quote",
+              "elements": [
+                { "type": "text", "text": "Dobrii vechir, everybady!" }
+              ]
+            },
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "text",
+                  "text": "code line",
+                  "style": { "code": true }
+                },
+                { "type": "text", "text": "\n" }
+              ]
+            },
+            {
+              "type": "rich_text_preformatted",
+              "elements": [
+                {
+                  "type": "text",
+                  "text": "var bar far;\n\npub sub mob dob;\ncucu"
+                }
+              ],
+              "border": 0
+            },
+            {
+              "type": "rich_text_section",
+              "elements": [
+                { "type": "text", "text": "The user mentioning line: " },
+                { "type": "user", "user_id": "U01DVDVMS12" }
+              ]
+            }
+          ]
+        }
+      ],
+      "team": "T01DK9EHX5F",
+      "attachments": [
+        {
+          "from_url": "https://calendar.google.com/calendar/u/1/r/week",
+          "service_icon": "https://accounts.google.com/favicon.ico",
+          "id": 1,
+          "original_url": "https://calendar.google.com/calendar/u/1/r/week",
+          "fallback": "Google Calendar - Sign in to Access & Edit Your Schedule",
+          "text": "Access Google Calendar with a free Google account (for personal use) or Google Workspace account (for business use).",
+          "title": "Google Calendar - Sign in to Access & Edit Your Schedule",
+          "title_link": "https://calendar.google.com/calendar/u/1/r/week",
+          "service_name": "accounts.google.com"
+        }
+      ]
+    }
+  }

--- a/slack-base/src/test/resources/unknown_blocks.json
+++ b/slack-base/src/test/resources/unknown_blocks.json
@@ -1,12 +1,12 @@
 [
   {
-    "type": "rich_text",
+    "type": "rich_text_unknown",
     "elements": [
       {
-        "type": "rich_text_section",
+        "type": "rich_text_section_unknown",
         "elements": [
           {
-            "type": "text",
+            "type": "text_unknown",
             "text": "blah"
           }
         ]


### PR DESCRIPTION
This PR adds message blocks, which are passed by Slack in the `message_action` payload. 
This will allow us to work with user messages in a much more sufficient way, removing the need to parse the Slack markdown text itself.