### PR TITLE
Default to `false` for text styles

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/TextStyleIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/messages/TextStyleIF.java
@@ -1,10 +1,13 @@
 package com.hubspot.slack.client.models.blocks.messages;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value;
+import org.immutables.value.Value.Default;
 
 import java.util.Optional;
 
@@ -12,12 +15,24 @@ import java.util.Optional;
 @HubSpotStyle
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public interface TextStyleIF {
+    @Default
     @JsonProperty("bold")
-    Optional<Boolean> isBold();
+    default boolean isBold() {
+        return false;
+    }
+    @Default
     @JsonProperty("italic")
-    Optional<Boolean> isItalic();
+    default boolean isItalic() {
+        return false;
+    }
+    @Default
     @JsonProperty("strike")
-    Optional<Boolean> isStrikethrough();
+    default boolean isStrikethrough() {
+        return false;
+    }
+    @Default
     @JsonProperty("code")
-    Optional<Boolean> isCode();
+    default boolean isCode() {
+        return false;
+    }
 }


### PR DESCRIPTION
We broke the serialization of `TextStyleIF` in https://github.com/HubSpot/slack-client/pull/304 because if `Optional` is empty we pass `"code": null` to Slack and it returns us response like this:
```
{
  "ok" : false,
  "error" : "invalid_blocks",
  "warning" : "missing_charset",
  "response_metadata" : {
    "messages" : [ "[ERROR] must be a boolean [json-pointer:/blocks/0/elements/0/elements/1/style/italic]", "[ERROR] must be a boolean [json-pointer:/blocks/0/elements/0/elements/1/style/strike]", "[ERROR] must be a boolean [json-pointer:/blocks/0/elements/0/elements/1/style/code]", "[ERROR] must be a boolean [json-pointer:/blocks/0/elements/0/elements/7/style/bold]", "[ERROR] must be a boolean [json-pointer:/blocks/0/elements/0/elements/7/style/italic]", "[ERROR] must be a boolean [json-pointer:/blocks/0/elements/0/elements/7/style/strike]" ],
    "warnings" : [ "missing_charset" ]
  }
}
```

We have to exclude the fields completely if `Optional` is empty or make them default to `false`. I think the latter option makes way more sense since `Optional<Boolean>` itself doesn't make a lot of sense and only complicates the interaction the code.