### PR TITLE
Update Team icon URL field

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/teams/SlackTeamIconIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/teams/SlackTeamIconIF.java
@@ -1,5 +1,6 @@
 package com.hubspot.slack.client.models.teams;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -12,7 +13,8 @@ import java.util.Optional;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface SlackTeamIconIF {
 
-  Optional<String> getImage_88();
+  @JsonProperty("image_88")
+  Optional<String> getImage88();
 
   @Deprecated
   Optional<String> getImageOriginal();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/teams/SlackTeamIconIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/teams/SlackTeamIconIF.java
@@ -1,17 +1,19 @@
 package com.hubspot.slack.client.models.teams;
 
-import java.util.Optional;
-
-import org.immutables.value.Value.Immutable;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value.Immutable;
+
+import java.util.Optional;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 public interface SlackTeamIconIF {
+
+  Optional<String> getImage_88();
+
+  @Deprecated
   Optional<String> getImageOriginal();
 }


### PR DESCRIPTION
We used `image_original` field for the team's icon URL. It is not present on the [team](https://api.slack.com/methods/team.info) object anymore. I didn't found announcement about this in the [changelog](https://api.slack.com/changelog) so I don't know the reason why it was removed. 
I updated the `SlackTeamIconIF` model to use `image_88` instead.