### PR TITLE
Add confirmation dialog `style` field

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/Style.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/Style.java
@@ -1,0 +1,30 @@
+package com.hubspot.slack.client.models.blocks;
+
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.hubspot.slack.client.enums.EnumIndex;
+import com.hubspot.slack.client.enums.UnmappedKeyException;
+
+public enum Style {
+  DEFAULT,
+  PRIMARY,
+  DANGER;
+
+  private static final EnumIndex<String, Style> INDEX = new EnumIndex<>(Style.class, Style::key);
+
+  @JsonCreator
+  public static Style get(String key) throws UnmappedKeyException {
+    return INDEX.get(key.toLowerCase());
+  }
+
+  public static Optional<Style> find(String key) {
+    return INDEX.find(key.toLowerCase());
+  }
+
+  @JsonValue
+  public String key() {
+    return name().toLowerCase();
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/ConfirmationDialogIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/ConfirmationDialogIF.java
@@ -1,5 +1,7 @@
 package com.hubspot.slack.client.models.blocks.objects;
 
+import java.util.Optional;
+
 import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
 
@@ -7,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.blocks.Style;
 
 @Immutable
 @HubSpotStyle
@@ -25,4 +28,6 @@ public interface ConfirmationDialogIF extends CompositionObject {
   @JsonProperty("deny")
   @Value.Parameter
   Text getDenyButtonText();
+
+  Optional<Style> getStyle();
 }


### PR DESCRIPTION
Add support for styling the confirmation dialog. Color schemes for the buttons in these 3 styles:
<img width="765" alt="image" src="https://user-images.githubusercontent.com/17253295/229190108-92d3e24b-c1f5-4fd5-9e9c-42401cd75305.png">

https://api.slack.com/reference/block-kit/composition-objects#confirm