### PR TITLE
Add ContextTeamId to SlackEventWrapper.

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventWrapperIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventWrapperIF.java
@@ -14,6 +14,7 @@ import com.hubspot.immutables.style.HubSpotStyle;
 public interface SlackEventWrapperIF<T extends SlackEvent> {
   String getToken();
   String getTeamId();
+  Optional<String> getContextTeamId();
   SlackEventType getType();
   List<String> getAuthedUsers();
   String getEventId();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventWrapperIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventWrapperIF.java
@@ -7,6 +7,7 @@ import org.immutables.value.Value.Immutable;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import java.util.Optional;
 
 @Immutable
 @HubSpotStyle


### PR DESCRIPTION
## Description
This PR adds ContextTeamId to SlackEventWrapper. I need this new field to extrude actual teamID for events that happened  in shared channels, since those events contains team ids for both workspaces. I made it optional because I don't want to break all the builds in the world. 

@zmarushchak-hs @omotnyk @motnyk @nliutyi-hs 