### PR TITLE
Support `"file_access": "access_denied"` in SlackFile model

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackAccessDeniedFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackAccessDeniedFileIF.java
@@ -1,21 +1,21 @@
 package com.hubspot.slack.client.models.files;
 
-import java.util.List;
-import java.util.Optional;
-
-import org.immutables.value.Value.Default;
-import org.immutables.value.Value.Immutable;
-
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import java.util.List;
+import java.util.Optional;
+import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Immutable;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-@JsonDeserialize(as = SlackUnknownFiletype.class)
-public interface SlackUnknownFiletypeIF extends SlackFile {
+@JsonDeserialize(as = SlackAccessDeniedFile.class)
+public interface SlackAccessDeniedFileIF extends SlackFile {
+  String getFileAccess();
+
   @Override
   @Default
   default String getId() {

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackCsvFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackCsvFileIF.java
@@ -4,12 +4,14 @@ import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackCsvFile.class)
 public interface SlackCsvFileIF extends SlackTextFileCore {
   @Default
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFile.java
@@ -1,30 +1,14 @@
 package com.hubspot.slack.client.models.files;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.hubspot.slack.client.models.files.json.SlackFileDeserializer;
 import java.util.List;
 import java.util.Optional;
 
 import org.immutables.value.Value.Default;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-
-@JsonTypeInfo(
-    use = Id.NAME,
-    include = As.EXISTING_PROPERTY,
-    property = "filetype",
-    defaultImpl = SlackUnknownFiletype.class
-)
-@JsonSubTypes({
-    @JsonSubTypes.Type(value = SlackTextFile.class, name = "text"),
-    @JsonSubTypes.Type(value = SlackCsvFile.class, name = "csv"),
-    @JsonSubTypes.Type(value = SlackGifFile.class, name = "gif"),
-    @JsonSubTypes.Type(value = SlackJpgFile.class, name = "jpg"),
-    @JsonSubTypes.Type(value = SlackPngFile.class, name = "png"),
-    @JsonSubTypes.Type(value = SlackJavaScriptFile.class, name = "javascript")
-})
+@JsonDeserialize(using = SlackFileDeserializer.class)
 public interface SlackFile {
   String getId();
   @JsonProperty("created")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileType.java
@@ -1,24 +1,27 @@
 package com.hubspot.slack.client.models.files;
 
 import java.util.stream.Stream;
+import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum SlackFileType {
-  TEXT("text"),
-  GIF("gif"),
-  CSV("csv"),
-  JPG("jpg"),
-  PNG("png"),
-  JAVASCRIPT("javascript"),
-  UNKNOWN("unknown"),
+  TEXT("text", SlackTextFile.class),
+  GIF("gif", SlackGifFile.class),
+  CSV("csv", SlackCsvFile.class),
+  JPG("jpg", SlackJpgFile.class),
+  PNG("png", SlackPngFile.class),
+  JAVASCRIPT("javascript", SlackJavaScriptFile.class),
+  UNKNOWN("unknown", SlackUnknownFiletype.class),
   ;
 
   final String type;
+  private final Class<? extends SlackFile> clazz;
 
-  SlackFileType(String type) {
+  SlackFileType(String type, Class<? extends SlackFile> clazz) {
     this.type = type;
+    this.clazz = clazz;
   }
 
   @JsonValue
@@ -28,9 +31,18 @@ public enum SlackFileType {
 
   @JsonCreator
   public static SlackFileType parse(String field) {
-    return Stream.of(values())
-        .filter(val -> val.getType().equalsIgnoreCase(field))
-        .findFirst()
+    return tryParse(field)
         .orElseThrow(() -> new IllegalArgumentException(field + " doesn't match any known slack file type"));
+  }
+
+  public static Optional<SlackFileType> tryParse(String field) {
+    return Stream
+        .of(values())
+        .filter(val -> val.getType().equalsIgnoreCase(field))
+        .findFirst();
+  }
+
+  public Class<? extends SlackFile> getFileTypeClass() {
+    return clazz;
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackGifFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackGifFileIF.java
@@ -4,12 +4,14 @@ import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackGifFile.class)
 public interface SlackGifFileIF extends SlackImageFile {
   @Default
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackJavaScriptFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackJavaScriptFileIF.java
@@ -4,13 +4,15 @@ import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
-public interface SlackJavaScriptFileIF extends SlackFile{
+@JsonDeserialize(as = SlackJavaScriptFile.class)
+public interface SlackJavaScriptFileIF extends SlackFile {
   @Default
   @Override
   default SlackFileType getFiletype() {

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackJpgFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackJpgFileIF.java
@@ -1,6 +1,7 @@
 package com.hubspot.slack.client.models.files;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value;
@@ -8,6 +9,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @HubSpotStyle
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackJpgFile.class)
 public interface SlackJpgFileIF extends SlackImageFile {
     @Value.Default
     @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackPngFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackPngFileIF.java
@@ -3,12 +3,14 @@ package com.hubspot.slack.client.models.files;
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 
 @Value.Immutable
 @HubSpotStyle
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackPngFile.class)
 public interface SlackPngFileIF extends SlackImageFile {
     @Value.Default
     @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackTextFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackTextFileIF.java
@@ -4,12 +4,14 @@ import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 
 @Immutable
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackTextFile.class)
 public interface SlackTextFileIF extends SlackTextFileCore {
   @Default
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/json/SlackFileDeserializer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/json/SlackFileDeserializer.java
@@ -1,0 +1,50 @@
+package com.hubspot.slack.client.models.files.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.hubspot.slack.client.models.files.SlackAccessDeniedFile;
+import com.hubspot.slack.client.models.files.SlackFile;
+import com.hubspot.slack.client.models.files.SlackFileType;
+import com.hubspot.slack.client.models.files.SlackUnknownFiletype;
+import com.hubspot.slack.client.models.files.SlackUnknownFiletypeIF;
+import java.io.IOException;
+import java.util.Optional;
+
+public class SlackFileDeserializer extends StdDeserializer<SlackFile> {
+  private static final String FILE_ACCESS_FIELD = "file_access";
+  private static final String FILE_TYPE_FIELD = "filetype";
+  private static final String ACCESS_DENIED = "access_denied";
+
+  public SlackFileDeserializer() {
+    super(SlackFile.class);
+  }
+
+  @Override
+  public SlackFile deserialize(JsonParser p, DeserializationContext ctxt)
+    throws IOException, JsonProcessingException {
+    ObjectCodec codec = p.getCodec();
+    JsonNode node = codec.readTree(p);
+
+    if (node.has(FILE_ACCESS_FIELD)) {
+      String fileAccess = node.get(FILE_ACCESS_FIELD).asText();
+      if (fileAccess.equalsIgnoreCase(ACCESS_DENIED)) {
+        return codec.treeToValue(node, SlackAccessDeniedFile.class);
+      }
+    }
+
+    Optional<SlackFileType> fileType = SlackFileType.tryParse(
+      node.get(FILE_TYPE_FIELD).asText()
+    );
+    if (fileType.isPresent()) {
+      return codec.treeToValue(node, fileType.get().getFileTypeClass());
+    }
+
+    ((ObjectNode) node).remove("filetype");
+    return codec.treeToValue(node, SlackUnknownFiletype.class);
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/files/SlackFileDeserializerTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/files/SlackFileDeserializerTest.java
@@ -1,0 +1,39 @@
+package com.hubspot.slack.client.models.files;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.hubspot.slack.client.jackson.ObjectMapperUtils;
+import com.hubspot.slack.client.models.JsonLoader;
+import java.io.IOException;
+import org.junit.Test;
+
+public class SlackFileDeserializerTest {
+
+  @Test
+  public void shouldDeserializeAccessDeniedFile() throws IOException {
+    SlackFile file = fetchAndDeserializeSlackFile("file_with_access_denied.json");
+    assertEquals(SlackFileType.PNG, file.getFiletype());
+    assertTrue(file instanceof SlackAccessDeniedFile);
+  }
+
+  @Test
+  public void shouldDeserializeKnownFileType() throws IOException {
+    SlackFile file = fetchAndDeserializeSlackFile("file_gif.json");
+    assertEquals(SlackFileType.GIF, file.getFiletype());
+    assertTrue(file instanceof SlackGifFile);
+  }
+
+  @Test
+  public void shouldDeserializeUnknownFile() throws IOException {
+    SlackFile file = fetchAndDeserializeSlackFile("file_unknown_type.json");
+    assertEquals(SlackFileType.UNKNOWN, file.getFiletype());
+    assertTrue(file instanceof SlackUnknownFiletype);
+    assertEquals("F0S43PZDF", file.getId());
+  }
+
+  private SlackFile fetchAndDeserializeSlackFile(String jsonFileName) throws IOException {
+    String rawJson = JsonLoader.loadJsonFromFile(jsonFileName);
+    return ObjectMapperUtils.mapper().readValue(rawJson, SlackFile.class);
+  }
+}

--- a/slack-base/src/test/resources/file_gif.json
+++ b/slack-base/src/test/resources/file_gif.json
@@ -1,0 +1,62 @@
+{
+  "id": "F0S43PZDF",
+  "created": 1531763342,
+  "timestamp": 1531763342,
+  "name": "tedair.gif",
+  "title": "tedair.gif",
+  "mimetype": "image/gif",
+  "filetype": "gif",
+  "pretty_type": "GIF",
+  "user": "U061F7AUR",
+  "editable": false,
+  "size": 137531,
+  "mode": "hosted",
+  "is_external": false,
+  "external_type": "",
+  "is_public": true,
+  "public_url_shared": false,
+  "display_as_bot": false,
+  "username": "",
+  "url_private": "https://.../tedair.gif",
+  "url_private_download": "https://.../tedair.gif",
+  "thumb_64": "https://.../tedair_64.png",
+  "thumb_80": "https://.../tedair_80.png",
+  "thumb_360": "https://.../tedair_360.png",
+  "thumb_360_w": 176,
+  "thumb_360_h": 226,
+  "thumb_160": "https://.../tedair_=_160.png",
+  "thumb_360_gif": "https://.../tedair_360.gif",
+  "image_exif_rotation": 1,
+  "original_w": 176,
+  "original_h": 226,
+  "deanimate_gif": "https://.../tedair_deanimate_gif.png",
+  "pjpeg": "https://.../tedair_pjpeg.jpg",
+  "permalink": "https://.../tedair.gif",
+  "permalink_public": "https://.../...",
+  "comments_count": 0,
+  "is_starred": false,
+  "shares": {
+    "public": {
+      "C0T8SE4AU": [
+        {
+          "reply_users": [
+            "U061F7AUR"
+          ],
+          "reply_users_count": 1,
+          "reply_count": 1,
+          "ts": "1531763348.000001",
+          "thread_ts": "1531763273.000015",
+          "latest_reply": "1531763348.000001",
+          "channel_name": "file-under",
+          "team_id": "T061EG9R6"
+        }
+      ]
+    }
+  },
+  "channels": [
+    "C0T8SE4AU"
+  ],
+  "groups": [],
+  "ims": [],
+  "has_rich_preview": false
+}

--- a/slack-base/src/test/resources/file_unknown_type.json
+++ b/slack-base/src/test/resources/file_unknown_type.json
@@ -1,0 +1,62 @@
+{
+  "id": "F0S43PZDF",
+  "created": 1531763342,
+  "timestamp": 1531763342,
+  "name": "tedair.gif",
+  "title": "tedair.gif",
+  "mimetype": "image/gif",
+  "filetype": "tiff",
+  "pretty_type": "TIFF",
+  "user": "U061F7AUR",
+  "editable": false,
+  "size": 137531,
+  "mode": "hosted",
+  "is_external": false,
+  "external_type": "",
+  "is_public": true,
+  "public_url_shared": false,
+  "display_as_bot": false,
+  "username": "",
+  "url_private": "https://.../tedair.gif",
+  "url_private_download": "https://.../tedair.gif",
+  "thumb_64": "https://.../tedair_64.png",
+  "thumb_80": "https://.../tedair_80.png",
+  "thumb_360": "https://.../tedair_360.png",
+  "thumb_360_w": 176,
+  "thumb_360_h": 226,
+  "thumb_160": "https://.../tedair_=_160.png",
+  "thumb_360_gif": "https://.../tedair_360.gif",
+  "image_exif_rotation": 1,
+  "original_w": 176,
+  "original_h": 226,
+  "deanimate_gif": "https://.../tedair_deanimate_gif.png",
+  "pjpeg": "https://.../tedair_pjpeg.jpg",
+  "permalink": "https://.../tedair.gif",
+  "permalink_public": "https://.../...",
+  "comments_count": 0,
+  "is_starred": false,
+  "shares": {
+    "public": {
+      "C0T8SE4AU": [
+        {
+          "reply_users": [
+            "U061F7AUR"
+          ],
+          "reply_users_count": 1,
+          "reply_count": 1,
+          "ts": "1531763348.000001",
+          "thread_ts": "1531763273.000015",
+          "latest_reply": "1531763348.000001",
+          "channel_name": "file-under",
+          "team_id": "T061EG9R6"
+        }
+      ]
+    }
+  },
+  "channels": [
+    "C0T8SE4AU"
+  ],
+  "groups": [],
+  "ims": [],
+  "has_rich_preview": false
+}

--- a/slack-base/src/test/resources/file_with_access_denied.json
+++ b/slack-base/src/test/resources/file_with_access_denied.json
@@ -1,0 +1,8 @@
+{
+  "id" : "SOMEID1234",
+  "file_access" : "access_denied",
+  "created" : 0,
+  "timestamp" : 0,
+  "user" : "",
+  "filetype" : "png"
+}


### PR DESCRIPTION
Currently we fail to parse Slack response like below. This PR adds custom deserialiser to handle responses like this.

```
{
      "id" : "F05RFJX6KL4",
      "file_access" : "access_denied",
      "created" : 0,
      "timestamp" : 0,
      "user" : "U01K1BQFK3R",
      "filetype" : "png"
    }
```