### PR TITLE
Add support for common spreadsheet file formats

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileType.java
@@ -14,7 +14,7 @@ public enum SlackFileType {
   PNG("png", SlackPngFile.class),
   JAVASCRIPT("javascript", SlackJavaScriptFile.class),
   XLSX("xlsx", SlackXlsxFile.class),
-  XLS("xlsx", SlackXlsFile.class),
+  XLS("xls", SlackXlsFile.class),
   UNKNOWN("unknown", SlackUnknownFiletype.class),
   ;
 

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileType.java
@@ -13,6 +13,8 @@ public enum SlackFileType {
   JPG("jpg", SlackJpgFile.class),
   PNG("png", SlackPngFile.class),
   JAVASCRIPT("javascript", SlackJavaScriptFile.class),
+  XLSX("xlsx", SlackXlsxFile.class),
+  XLS("xlsx", SlackXlsFile.class),
   UNKNOWN("unknown", SlackUnknownFiletype.class),
   ;
 

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackXlsFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackXlsFileIF.java
@@ -1,0 +1,21 @@
+package com.hubspot.slack.client.models.files;
+
+import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackXlsFile.class)
+public interface SlackXlsFileIF extends SlackFile {
+  @Default
+  @Override
+  default SlackFileType getFiletype() {
+    return SlackFileType.XLS;
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackXlsxFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackXlsxFileIF.java
@@ -1,0 +1,21 @@
+package com.hubspot.slack.client.models.files;
+
+import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Immutable;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackXlsxFile.class)
+public interface SlackXlsxFileIF extends SlackFile {
+  @Default
+  @Override
+  default SlackFileType getFiletype() {
+    return SlackFileType.XLSX;
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/files/SlackFileDeserializerTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/files/SlackFileDeserializerTest.java
@@ -39,6 +39,20 @@ public class SlackFileDeserializerTest {
   }
 
   @Test
+  public void shouldDeserializeXlsFileType() throws IOException {
+    SlackFile file = fetchAndDeserializeSlackFile("file_xls.json");
+    assertEquals(SlackFileType.XLS, file.getFiletype());
+    assertTrue(file instanceof SlackXlsFile);
+  }
+
+  @Test
+  public void shouldDeserializeXlsxFileType() throws IOException {
+    SlackFile file = fetchAndDeserializeSlackFile("file_xlsx.json");
+    assertEquals(SlackFileType.XLSX, file.getFiletype());
+    assertTrue(file instanceof SlackXlsxFile);
+  }
+
+  @Test
   public void shouldDeserializeUnknownFile() throws IOException {
     SlackFile file = fetchAndDeserializeSlackFile("file_unknown_type.json");
     assertEquals(SlackFileType.UNKNOWN, file.getFiletype());

--- a/slack-base/src/test/resources/file_xls.json
+++ b/slack-base/src/test/resources/file_xls.json
@@ -1,0 +1,50 @@
+{
+  "id": "F0S43PZDF",
+  "created": 1531763342,
+  "timestamp": 1531763342,
+  "name": "spreadsheet.xls",
+  "title": "spreadsheet.xls",
+  "mimetype": "application/vnd.ms-excel",
+  "filetype": "xls",
+  "pretty_type": "XLS",
+  "user": "U061F7AUR",
+  "editable": false,
+  "size": 137531,
+  "mode": "hosted",
+  "is_external": false,
+  "external_type": "",
+  "is_public": true,
+  "public_url_shared": false,
+  "display_as_bot": false,
+  "username": "",
+  "url_private": "https://.../spreadsheet.xls",
+  "url_private_download": "https://.../spreadsheet.xls",
+  "permalink": "https://.../spreadsheet.xls",
+  "permalink_public": "https://.../...",
+  "comments_count": 0,
+  "is_starred": false,
+  "shares": {
+    "public": {
+      "C0T8SE4AU": [
+        {
+          "reply_users": [
+            "U061F7AUR"
+          ],
+          "reply_users_count": 1,
+          "reply_count": 1,
+          "ts": "1531763348.000001",
+          "thread_ts": "1531763273.000015",
+          "latest_reply": "1531763348.000001",
+          "channel_name": "file-under",
+          "team_id": "T061EG9R6"
+        }
+      ]
+    }
+  },
+  "channels": [
+    "C0T8SE4AU"
+  ],
+  "groups": [],
+  "ims": [],
+  "has_rich_preview": false
+}

--- a/slack-base/src/test/resources/file_xlsx.json
+++ b/slack-base/src/test/resources/file_xlsx.json
@@ -1,0 +1,50 @@
+{
+  "id": "F0S43PZDF",
+  "created": 1531763342,
+  "timestamp": 1531763342,
+  "name": "spreadsheet.xlsx",
+  "title": "spreadsheet.xlsx",
+  "mimetype": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "filetype": "xlsx",
+  "pretty_type": "XLSX",
+  "user": "U061F7AUR",
+  "editable": false,
+  "size": 137531,
+  "mode": "hosted",
+  "is_external": false,
+  "external_type": "",
+  "is_public": true,
+  "public_url_shared": false,
+  "display_as_bot": false,
+  "username": "",
+  "url_private": "https://.../spreadsheet.xlsx",
+  "url_private_download": "https://.../spreadsheet.xlsx",
+  "permalink": "https://.../spreadsheet.xlsx",
+  "permalink_public": "https://.../...",
+  "comments_count": 0,
+  "is_starred": false,
+  "shares": {
+    "public": {
+      "C0T8SE4AU": [
+        {
+          "reply_users": [
+            "U061F7AUR"
+          ],
+          "reply_users_count": 1,
+          "reply_count": 1,
+          "ts": "1531763348.000001",
+          "thread_ts": "1531763273.000015",
+          "latest_reply": "1531763348.000001",
+          "channel_name": "file-under",
+          "team_id": "T061EG9R6"
+        }
+      ]
+    }
+  },
+  "channels": [
+    "C0T8SE4AU"
+  ],
+  "groups": [],
+  "ims": [],
+  "has_rich_preview": false
+}


### PR DESCRIPTION
Been writing a job that generates a spreadsheet report and sends it to a slack channel. Without a proper type it reports in the slack UI as `Binary`. The file still works so this isn't blocking, but seems worthwhile to cover.

These types are in the [supported listing](https://api.slack.com/types/file#types). Let me know if I'm missing any related implementation details required to support this.