### PR TITLE
Add additional view input types

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewInputType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewInputType.java
@@ -6,8 +6,12 @@ import com.hubspot.slack.client.enums.EnumIndex;
 
 public enum ViewInputType {
   PLAIN_TEXT_INPUT,
+  EMAIL_TEXT_INPUT,
+  URL_TEXT_INPUT,
+  NUMBER_INPUT,
   DATEPICKER,
   TIMEPICKER,
+  DATETIMEPICKER,
   RADIO_BUTTONS,
   USERS_SELECT,
   EXTERNAL_SELECT,


### PR DESCRIPTION
The following values are missing from the `ViewInputType` enum, causing those input types to be deserialized to "unknown". The enum is updated here so that the `ViewInput` objects can actually be built.

Note that `ViewInput` already includes the types `ViewEmailInput`, `ViewUrlInput`, `ViewNumberInput`, and `ViewDateTimePicker`.

Similar issue to https://github.com/HubSpot/slack-client/pull/271