### PR TITLE
support deserializing empty files with mode="tombstone"

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileTombstoneIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileTombstoneIF.java
@@ -1,0 +1,19 @@
+package com.hubspot.slack.client.models.files;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackFileTombstone.class)
+public interface SlackFileTombstoneIF extends SlackFileError {
+  @Override
+  @Value.Default
+  default String getFileAccess() {
+    return "unknown";
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/json/SlackFileDeserializer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/json/SlackFileDeserializer.java
@@ -12,6 +12,7 @@ import com.hubspot.slack.client.models.files.SlackFile;
 import com.hubspot.slack.client.models.files.SlackFileDeletedFile;
 import com.hubspot.slack.client.models.files.SlackFileError;
 import com.hubspot.slack.client.models.files.SlackFileNotFoundFile;
+import com.hubspot.slack.client.models.files.SlackFileTombstone;
 import com.hubspot.slack.client.models.files.SlackFileType;
 import com.hubspot.slack.client.models.files.SlackUnknownFiletype;
 import com.hubspot.slack.client.models.response.SlackErrorType;
@@ -23,6 +24,7 @@ import java.util.Optional;
 public class SlackFileDeserializer extends StdDeserializer<SlackFile> {
 
   private static final String FILE_ACCESS_FIELD = "file_access";
+  private static final String FILE_MODE_FIELD = "mode";
   private static final String FILE_TYPE_FIELD = "filetype";
   private static final Map<String, Class<? extends SlackFileError>> fileTypeErrorClasses;
 
@@ -58,6 +60,13 @@ public class SlackFileDeserializer extends StdDeserializer<SlackFile> {
         Optional.ofNullable(fileTypeErrorClasses.get(fileAccess.toLowerCase()));
       if (errorClass.isPresent()) {
         return codec.treeToValue(node, errorClass.get());
+      }
+    }
+
+    if (node.has(FILE_MODE_FIELD)) {
+      String fileMode = node.get(FILE_MODE_FIELD).asText();
+      if (fileMode.equals("tombstone")) {
+        return codec.treeToValue(node, SlackFileTombstone.class);
       }
     }
 

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/files/SlackFileDeserializerTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/files/SlackFileDeserializerTest.java
@@ -11,6 +11,13 @@ import org.junit.Test;
 public class SlackFileDeserializerTest {
 
   @Test
+  public void shouldDeserializeTombstone() throws IOException {
+    SlackFile file = fetchAndDeserializeSlackFile("file_with_tombstone.json");
+    assertEquals(SlackFileType.UNKNOWN, file.getFiletype());
+    assertTrue(file instanceof SlackFileTombstone);
+  }
+
+  @Test
   public void shouldDeserializeDeleted() throws IOException {
     SlackFile file = fetchAndDeserializeSlackFile("file_with_file_deleted.json");
     assertEquals(SlackFileType.PNG, file.getFiletype());

--- a/slack-base/src/test/resources/file_with_tombstone.json
+++ b/slack-base/src/test/resources/file_with_tombstone.json
@@ -1,0 +1,4 @@
+{
+  "id": "F04QS86SFML",
+  "mode": "tombstone"
+}


### PR DESCRIPTION
Currently deserialization fails for responses with this shape:

```json
{
  "messages" : [ {
    "files" : [ {
      "id" : "F04QS86SFML",
      "mode" : "tombstone"
    } ],
```

with error:
```
Caused by: java.lang.NullPointerException: Cannot invoke "com.fasterxml.jackson.databind.JsonNode.asText()" because the return value of "com.fasterxml.jackson.databind.JsonNode.get(String)" is null
	at com.hubspot.slack.client.models.files.json.SlackFileDeserializer.deserialize(SlackFileDeserializer.java:55)
	at com.hubspot.slack.client.models.files.json.SlackFileDeserializer.deserialize(SlackFileDeserializer.java:24)
```
