### PR TITLE
Fix deprecation warnings

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/jackson/AttachmentSerializer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/jackson/AttachmentSerializer.java
@@ -63,7 +63,12 @@ public class AttachmentSerializer extends StdSerializer<Attachment> {
     JavaType javaType = provider.constructType(Attachment.class);
     BeanDescription beanDesc = provider.getConfig().introspect(javaType);
     JsonSerializer<Object> defaultSerializer =
-      BeanSerializerFactory.instance.findBeanSerializer(provider, javaType, beanDesc);
+      BeanSerializerFactory.instance.findBeanOrAddOnSerializer(
+        provider,
+        javaType,
+        beanDesc,
+        false
+      );
     defaultSerializer.serialize(attachment, jgen, provider);
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/jackson/ObjectMapperUtils.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/jackson/ObjectMapperUtils.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
-import com.fasterxml.jackson.datatype.jsr310.JSR310Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -23,7 +23,7 @@ public final class ObjectMapperUtils {
     mapper.registerModule(new GuavaModule());
     mapper.registerModule(new JodaModule());
     mapper.registerModule(new Jdk8Module());
-    mapper.registerModule(new JSR310Module());
+    mapper.registerModule(new JavaTimeModule());
 
     mapper.configure(JsonParser.Feature.ALLOW_COMMENTS, false);
     mapper.configure(JsonParser.Feature.AUTO_CLOSE_SOURCE, true);

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/bookmarks/BookmarksAddParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/bookmarks/BookmarksAddParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.bookmarks;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasChannel;
@@ -11,7 +11,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface BookmarksAddParamsIF extends HasChannel {
   @Value.Derived
@@ -20,10 +20,14 @@ public interface BookmarksAddParamsIF extends HasChannel {
   }
 
   String getTitle();
+
   BookmarkType getType();
 
   Optional<String> getEmoji();
+
   Optional<String> getEntityId();
+
   Optional<String> getLink();
+
   Optional<String> getParentId();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/bookmarks/BookmarksEditParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/bookmarks/BookmarksEditParamsIF.java
@@ -1,17 +1,16 @@
 package com.hubspot.slack.client.methods.params.bookmarks;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasChannel;
-import com.hubspot.slack.client.models.bookmarks.BookmarkType;
 import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface BookmarksEditParamsIF extends HasChannel {
   @Value.Derived
@@ -22,6 +21,8 @@ public interface BookmarksEditParamsIF extends HasChannel {
   String getBookmarkId();
 
   Optional<String> getEmoji();
+
   Optional<String> getLink();
+
   Optional<String> getTitle();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/bookmarks/BookmarksListParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/bookmarks/BookmarksListParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.bookmarks;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasChannel;
@@ -9,7 +9,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface BookmarksListParamsIF extends HasChannel {
   @Value.Derived

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/bookmarks/BookmarksRemoveParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/bookmarks/BookmarksRemoveParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.bookmarks;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasChannel;
@@ -9,7 +9,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface BookmarksRemoveParamsIF extends HasChannel {
   @Value.Derived

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/calls/CallsAddParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/calls/CallsAddParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.calls;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.calls.SlackInternalOrExternalUser;
@@ -11,7 +11,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface CallsAddParamsIF {
   String getExternalUniqueId();

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/calls/CallsEndParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/calls/CallsEndParamsIF.java
@@ -3,7 +3,7 @@ package com.hubspot.slack.client.methods.params.calls;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.primitives.Ints;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -13,7 +13,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface CallsEndParamsIF {
   @Value.Parameter(order = 0)

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/calls/CallsInfoParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/calls/CallsInfoParamsIF.java
@@ -1,14 +1,14 @@
 package com.hubspot.slack.client.methods.params.calls;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface CallsInfoParamsIF {
   @Value.Parameter(order = 0)

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/calls/CallsParticipantsAddParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/calls/CallsParticipantsAddParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.calls;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.calls.SlackInternalOrExternalUser;
@@ -10,7 +10,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface CallsParticipantsAddParamsIF {
   String getId();

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/calls/CallsParticipantsRemoveParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/calls/CallsParticipantsRemoveParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.calls;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.calls.SlackInternalOrExternalUser;
@@ -10,7 +10,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface CallsParticipantsRemoveParamsIF {
   String getId();

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/calls/CallsUpdateParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/calls/CallsUpdateParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.calls;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;
@@ -9,11 +9,14 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface CallsUpdateParamsIF {
   String getId();
+
   Optional<String> getDesktopAppJoinUrl();
+
   Optional<String> getJoinUrl();
+
   Optional<String> getTitle();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/channels/AbstractChannelsHistoryParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/channels/AbstractChannelsHistoryParams.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.channels;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Preconditions;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/channels/AbstractChannelsInfoParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/channels/AbstractChannelsInfoParams.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.channels;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasChannel;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/channels/ChannelsFilterIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/channels/ChannelsFilterIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.methods.params.channels;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Immutable;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/channels/ChannelsKickParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/channels/ChannelsKickParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.channels;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasChannel;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/channels/ChannelsListParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/channels/ChannelsListParamsIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.methods.params.channels;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;
@@ -11,5 +11,6 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ChannelsListParamsIF extends BaseChannelsFilter {
   Optional<String> getCursor();
+
   Optional<Integer> getLimit();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractChatDeleteParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractChatDeleteParams.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.methods.params.chat;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasChannel;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractChatMessageParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractChatMessageParams.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.methods.params.chat;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractChatPostMessageParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractChatPostMessageParams.java
@@ -1,7 +1,5 @@
 package com.hubspot.slack.client.methods.params.chat;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Immutable;
 

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractSlashCommandResponseParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/AbstractSlashCommandResponseParams.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.methods.params.chat;
 
 import static com.hubspot.slack.client.models.TopLevelMessageResponseType.EPHEMERAL;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.TopLevelMessageResponseType;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatDeleteScheduledMessageParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatDeleteScheduledMessageParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.chat;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasChannel;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatGetPermalinkParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatGetPermalinkParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.chat;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasChannel;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatScheduleMessageParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatScheduleMessageParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.chat;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatScheduledMessagesListParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatScheduledMessagesListParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.chat;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Default;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatUnfurlBlocksIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatUnfurlBlocksIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.methods.params.chat;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -12,7 +12,7 @@ import org.immutables.value.Value;
 
 @HubSpotStyle
 @Value.Immutable
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface ChatUnfurlBlocksIF extends ChatUnfurlBlocksOrAttachment {
   @Value.Parameter(order = 1)
   @JsonDeserialize(contentUsing = BlockOrAttachmentDeserializer.class)

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatUnfurlParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatUnfurlParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.chat;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatUpdateMessageParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/ChatUpdateMessageParamsIF.java
@@ -3,7 +3,7 @@ package com.hubspot.slack.client.methods.params.chat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/AbstractConversationsHistoryParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/AbstractConversationsHistoryParams.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.conversations;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.TimeIntervalFilter;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationCreateParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationCreateParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.conversations;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Immutable;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationInviteParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationInviteParamsIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.methods.params.conversations;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Joiner;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationMemberParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationMemberParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.conversations;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;
@@ -9,9 +9,10 @@ import org.immutables.value.Value.Immutable;
 
 @Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface ConversationMemberParamsIF {
   Optional<String> getCursor();
+
   Optional<Integer> getLimit();
 
   @JsonProperty("channel")

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationOpenParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationOpenParamsIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.methods.params.conversations;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Joiner;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationsInfoParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationsInfoParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.conversations;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;
@@ -11,9 +11,11 @@ import org.immutables.value.Value.Immutable;
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ConversationsInfoParamsIF {
-  @JsonProperty("channel") // could be a channel ID, group ID, IM ID
+  @JsonProperty("channel")
+  // could be a channel ID, group ID, IM ID
   String getConversationId();
 
   Optional<Boolean> getIncludeLocale();
+
   Optional<Boolean> getIncludeNumMembers();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationsJoinParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationsJoinParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.conversations;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Immutable;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationsListParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationsListParamsIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.methods.params.conversations;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;
@@ -11,5 +11,6 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ConversationsListParamsIF extends BaseConversationsFilter {
   Optional<String> getCursor();
+
   Optional<Integer> getLimit();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationsRepliesParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationsRepliesParamsIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.methods.params.conversations;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Immutable;
@@ -10,5 +10,6 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ConversationsRepliesParamsIF {
   String getChannel();
+
   String getTs();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationsUserParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/conversations/ConversationsUserParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.conversations;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;
@@ -15,5 +15,6 @@ public interface ConversationsUserParamsIF extends BaseConversationsFilter {
   Optional<String> getUserId();
 
   Optional<String> getCursor();
+
   Optional<Integer> getLimit();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/dialog/DialogOpenParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/dialog/DialogOpenParamsIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.methods.params.dialog;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.dialog.SlackDialog;
@@ -14,5 +14,6 @@ import org.immutables.value.Value.Immutable;
 @JsonInclude(Include.NON_EMPTY)
 public interface DialogOpenParamsIF {
   String getTriggerId();
+
   SlackDialog getDialog();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/dnd/DndSetSnoozeParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/dnd/DndSetSnoozeParamsIF.java
@@ -1,14 +1,13 @@
 package com.hubspot.slack.client.methods.params.dnd;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface DndSetSnoozeParamsIF {
   int getNumMinutes();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/files/FilesSharedPublicUrlParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/files/FilesSharedPublicUrlParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.files;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Immutable;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/files/FilesUploadParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/files/FilesUploadParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.files;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.files.SlackFileType;
@@ -16,12 +16,19 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface FilesUploadParamsIF {
   List<String> getChannels();
+
   Optional<String> getContent();
+
   Optional<File> getFile();
+
   Optional<String> getFilename();
+
   Optional<SlackFileType> getFiletype();
+
   Optional<String> getInitialComment();
+
   Optional<String> getThreadTs();
+
   Optional<String> getTitle();
 
   @Check

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/group/GroupsKickParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/group/GroupsKickParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.group;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasChannel;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/group/GroupsListParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/group/GroupsListParamsIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.methods.params.group;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.params.channels.BaseChannelsFilter;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/im/ImOpenParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/im/ImOpenParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.im;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasUser;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/migration/MigrationExchangeParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/migration/MigrationExchangeParamsIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.methods.params.migration;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Joiner;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/reactions/ReactionsAddParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/reactions/ReactionsAddParamsIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.methods.params.reactions;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.immutables.validation.ImmutableConditions;
@@ -13,13 +13,15 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ReactionsAddParamsIF {
   String getName();
+
   Optional<String> getChannel();
+
   Optional<String> getTimestamp();
 
   /**
    * @deprecated As of 22nd August 2019, Slack has removed support for file comments -
    * <a href="https://api.slack.com/changelog/2018-05-file-threads-soon-tread#whats_changed">
-   *   file threads are the replacement
+   * file threads are the replacement
    * </a>
    */
   @Deprecated
@@ -28,7 +30,7 @@ public interface ReactionsAddParamsIF {
   /**
    * @deprecated As of 22nd August 2019, Slack has removed support for file comments -
    * <a href="https://api.slack.com/changelog/2018-05-file-threads-soon-tread#whats_changed">
-   *   file threads are the replacement
+   * file threads are the replacement
    * </a>
    */
   @Deprecated

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/usergroups/AbstractUsergroupDisableParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/usergroups/AbstractUsergroupDisableParams.java
@@ -3,7 +3,7 @@ package com.hubspot.slack.client.methods.params.usergroups;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasUsergroup;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/usergroups/AbstractUsergroupUpdateParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/usergroups/AbstractUsergroupUpdateParams.java
@@ -3,7 +3,7 @@ package com.hubspot.slack.client.methods.params.usergroups;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasCommaSeperatedChannelIds;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/usergroups/UsergroupCreateParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/usergroups/UsergroupCreateParamsIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.methods.params.usergroups;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasCommaSeperatedChannelIds;
@@ -17,6 +17,8 @@ public interface UsergroupCreateParamsIF extends HasCommaSeperatedChannelIds {
   String getName();
 
   Optional<String> getDescription();
+
   Optional<String> getHandle();
+
   Optional<Boolean> getIncludeCount();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/usergroups/UsergroupEnableParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/usergroups/UsergroupEnableParamsIF.java
@@ -3,7 +3,7 @@ package com.hubspot.slack.client.methods.params.usergroups;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/usergroups/UsergroupListParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/usergroups/UsergroupListParamsIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.methods.params.usergroups;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;
@@ -14,6 +14,8 @@ import org.immutables.value.Value.Immutable;
 @JsonInclude(Include.NON_EMPTY)
 public interface UsergroupListParamsIF {
   Optional<Boolean> getIncludeCount();
+
   Optional<Boolean> getIncludeDisabled();
+
   Optional<Boolean> getIncludeUsers();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/usergroups/users/AbstractUsergroupUsersUpdateParams.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/usergroups/users/AbstractUsergroupUsersUpdateParams.java
@@ -3,7 +3,7 @@ package com.hubspot.slack.client.methods.params.usergroups.users;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasCommaSeperatedUserIds;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/users/SetUserProfileParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/users/SetUserProfileParamsIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.methods.params.users;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasUser;
@@ -12,7 +12,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface SetUserProfileParamsIF extends HasUser {
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/users/UsersListParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/users/UsersListParamsIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.methods.params.users;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;
@@ -11,5 +11,6 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface UsersListParamsIF {
   Optional<String> getCursor();
+
   Optional<Integer> getLimit();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/views/OpenViewParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/views/OpenViewParamsIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.methods.params.views;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.views.ModalViewPayload;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/views/PublishViewParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/views/PublishViewParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.views;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.views.HomeTabViewPayload;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/views/UpdateViewParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/views/UpdateViewParamsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.methods.params.views;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -21,7 +21,9 @@ public interface UpdateViewParamsIF {
   ModalViewPayload getView();
 
   Optional<String> getExternalId();
+
   Optional<String> getHash();
+
   Optional<String> getViewId();
 
   @Check

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/AttachmentIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/AttachmentIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.models;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -20,19 +20,33 @@ import org.immutables.value.Value.Immutable;
 @JsonSerialize(using = AttachmentSerializer.class)
 public interface AttachmentIF extends BlockOrAttachment {
   Optional<String> getFallback();
+
   Optional<String> getColor();
+
   Optional<String> getPretext();
+
   Optional<String> getAuthorName();
+
   Optional<String> getAuthorLink();
+
   Optional<String> getAuthorIcon();
+
   Optional<String> getTitle();
+
   Optional<String> getTitleLink();
+
   Optional<String> getText();
+
   Optional<String> getImageUrl();
+
   Optional<String> getAttachmentType();
+
   List<Field> getFields();
+
   Optional<String> getFooter();
+
   Optional<String> getFooterIcon();
+
   Optional<String> getThumbUrl();
 
   @JsonProperty("ts")
@@ -42,7 +56,9 @@ public interface AttachmentIF extends BlockOrAttachment {
 
   List<Action> getActions();
 
-  /** Slack will only markdown in fields whose names are included in this set. See {@link MarkdownSupportedFields}*/
+  /**
+   * Slack will only markdown in fields whose names are included in this set. See {@link MarkdownSupportedFields}
+   */
   Set<String> getMrkdwnIn();
 
   @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/ChannelMetadataIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/ChannelMetadataIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Immutable;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/FieldIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/FieldIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;
@@ -12,6 +12,7 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface FieldIF {
   Optional<String> getTitle();
+
   String getValue();
 
   @JsonProperty("short")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/LiteMessageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/LiteMessageIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.Block;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/ReactionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/ReactionIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.List;
@@ -11,6 +11,8 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ReactionIF {
   String getName();
+
   int getCount();
+
   List<String> getUsers();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/ReplySkeletonIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/ReplySkeletonIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Immutable;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/ScheduledMessageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/ScheduledMessageIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Immutable;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/SlackChannelIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/SlackChannelIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;
@@ -13,11 +13,17 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface SlackChannelIF {
   String getId();
+
   String getName();
+
   Optional<Boolean> getIsArchived();
+
   Optional<Boolean> getIsGeneral();
+
   Optional<Boolean> getIsPrivate();
+
   Optional<Boolean> getIsMember();
+
   Optional<Boolean> getIsShared();
 
   @Derived

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/actions/ActionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/actions/ActionIF.java
@@ -3,7 +3,7 @@ package com.hubspot.slack.client.models.actions;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.List;
@@ -19,9 +19,13 @@ public interface ActionIF {
   Optional<String> getName();
 
   ActionType getType();
+
   Optional<String> getText();
+
   Optional<String> getValue();
+
   Optional<Confirm> getConfirm();
+
   Optional<String> getUrl();
 
   @JsonProperty("style")
@@ -33,7 +37,10 @@ public interface ActionIF {
   }
 
   List<Option> getOptions();
+
   List<Option> getSelectedOptions();
+
   Optional<SlackDataSource> getDataSource();
+
   Optional<Integer> getMinQueryLength();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/actions/ConfirmIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/actions/ConfirmIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.actions;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Immutable;
@@ -10,7 +10,10 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ConfirmIF {
   String getTitle();
+
   String getText();
+
   String getOkText();
+
   String getDismissText();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/auth/BotCredentialsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/auth/BotCredentialsIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.auth;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Immutable;
@@ -10,5 +10,6 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface BotCredentialsIF {
   String getBotUserId();
+
   String getBotAccessToken();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/auth/IncomingWebhookIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/auth/IncomingWebhookIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.auth;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Immutable;
@@ -10,6 +10,8 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface IncomingWebhookIF {
   String getUrl();
+
   String getChannel();
+
   String getConfigurationUrl();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/auth/OAuthCredentialsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/auth/OAuthCredentialsIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.auth;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;
@@ -11,10 +11,16 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface OAuthCredentialsIF {
   String getAccessToken();
+
   String getTeamName();
+
   String getTeamId();
+
   Optional<String> getScope();
+
   Optional<String> getUserId();
+
   Optional<BotCredentials> getBot();
+
   Optional<IncomingWebhook> getIncomingWebhook();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/auth/OAuthV2CredentialsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/auth/OAuthV2CredentialsIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.auth;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.teams.SlackTeamLite;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ActionsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ActionsIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.blocks;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.elements.BlockElement;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/CallIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/CallIF.java
@@ -1,13 +1,13 @@
 package com.hubspot.slack.client.models.blocks;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface CallIF extends Block {
   String TYPE = "call";
 

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ContextIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ContextIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.blocks;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/DividerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/DividerIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.blocks;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/FileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/FileIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.blocks;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/HeaderIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/HeaderIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.blocks;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Preconditions;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ImageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ImageIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.blocks;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.objects.ImageBlockOrText;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/InputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/InputIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.elements.BlockElement;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.blocks;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ButtonIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ButtonIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelSelectMenuIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelsMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ChannelsMultiSelectMenuIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/CheckboxesIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/CheckboxesIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -16,7 +16,7 @@ import org.immutables.value.Value.Check;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface CheckboxesIF extends BlockElement, HasActionId {
   String TYPE = "checkboxes";
 

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationSelectMenuIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationsMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ConversationsMultiSelectMenuIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/DatePickerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/DatePickerIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/DateTimePickerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/DateTimePickerIF.java
@@ -1,13 +1,11 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;
 import com.hubspot.slack.client.models.blocks.objects.Text;
-import java.time.LocalDate;
 import java.util.Optional;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/EmailInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/EmailInputIF.java
@@ -1,7 +1,6 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalMultiSelectMenuIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ExternalSelectMenuIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ImageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/ImageIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/NumberInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/NumberInputIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/OverflowMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/OverflowMenuIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/PlainTextInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/PlainTextInputIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/RadioButtonGroupIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/RadioButtonGroupIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticMultiSelectMenuIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/StaticSelectMenuIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/TimePickerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/TimePickerIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UrlInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UrlInputIF.java
@@ -1,7 +1,6 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UserSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UserSelectMenuIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UsersMultiSelectMenuIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UsersMultiSelectMenuIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.objects.ConfirmationDialog;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/ConfirmationDialogIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/ConfirmationDialogIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.Style;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionGroupIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionGroupIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.blocks.objects;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/OptionIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.blocks.objects;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/TextIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/objects/TextIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.blocks.objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/bookmarks/BookmarkIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/bookmarks/BookmarkIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.models.bookmarks;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.time.Instant;
@@ -11,16 +11,22 @@ import org.immutables.value.Value;
 
 @HubSpotStyle
 @Value.Immutable
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface BookmarkIF {
   BookmarkType getType();
+
   String getId();
+
   String getChannelId();
+
   String getTitle();
 
   Optional<String> getLink();
+
   Optional<String> getEmoji();
+
   Optional<String> getIconUrl();
+
   Optional<String> getEntityId();
 
   @JsonProperty("date_created")
@@ -42,8 +48,12 @@ public interface BookmarkIF {
   }
 
   Optional<String> getRank();
+
   Optional<String> getLastUpdatedByUserId();
+
   Optional<String> getLastUpdatedByTeamId();
+
   Optional<String> getShortcutId();
+
   Optional<String> getAppId();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/calls/ExternalCallsUserIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/calls/ExternalCallsUserIF.java
@@ -1,15 +1,17 @@
 package com.hubspot.slack.client.models.calls;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value;
 
 @HubSpotStyle
 @Value.Immutable
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface ExternalCallsUserIF extends SlackInternalOrExternalUser {
   String getExternalId();
+
   String getDisplayName();
+
   String getAvatarUrl();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/calls/SlackCallIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/calls/SlackCallIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.models.calls;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -14,7 +14,7 @@ import org.immutables.value.Value;
 
 @HubSpotStyle
 @Value.Immutable
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface SlackCallIF {
   String getExternalUniqueId();
 

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/calls/SlackCallsUserIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/calls/SlackCallsUserIF.java
@@ -1,13 +1,13 @@
 package com.hubspot.slack.client.models.calls;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value;
 
 @HubSpotStyle
 @Value.Immutable
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface SlackCallsUserIF extends SlackInternalOrExternalUser {
   @Value.Parameter(order = 1)
   String getSlackId();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/calls/SlackInternalOrExternalUser.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/calls/SlackInternalOrExternalUser.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.calls;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface SlackInternalOrExternalUser {}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/channel/ImChannelIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/channel/ImChannelIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.channel;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Immutable;
@@ -10,9 +10,14 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ImChannelIF {
   String getId();
+
   int getCreated();
+
   boolean getIsIm();
+
   boolean getIsOrgShared();
+
   String getUser();
+
   boolean getIsOpen();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/commands/SlashCommandSubmissionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/commands/SlashCommandSubmissionIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.commands;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;
@@ -11,21 +11,31 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface SlashCommandSubmissionIF {
   String getToken();
+
   String getTeamId();
+
   String getTeamDomain();
+
   Optional<String> getEnterpriseId();
+
   Optional<String> getEnterpriseName();
+
   String getChannelId();
+
   String getChannelName();
+
   String getUserId();
+
   String getCommand();
+
   String getText();
+
   String getResponseUrl();
+
   String getTriggerId();
 
   /**
-   * @deprecated
-   * The user_name field is being phased out
+   * @deprecated The user_name field is being phased out
    * https://api.slack.com/changelog/2017-09-the-one-about-usernames
    */
   @Deprecated

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/conversations/ConversationIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/conversations/ConversationIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.conversations;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;
@@ -12,6 +12,7 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ConversationIF {
   String getId();
+
   Optional<String> getName();
 
   @JsonProperty("is_channel")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/SlackDialogIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/SlackDialogIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.models.dialog;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Strings;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -18,10 +18,15 @@ import org.immutables.value.Value.Immutable;
 @JsonInclude(Include.NON_EMPTY)
 public interface SlackDialogIF {
   String getTitle();
+
   String getCallbackId();
+
   List<SlackDialogFormElement> getElements();
+
   Optional<String> getState();
+
   Optional<String> getSubmitLabel();
+
   Optional<Boolean> getNotifyOnCancel();
 
   @Check

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormSelectElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormSelectElement.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.models.dialog.form.elements;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.actions.SlackDataSource;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextElement.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.models.dialog.form.elements;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.dialog.form.SlackFormElementTypes;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextareaElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/AbstractSlackFormTextareaElement.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.models.dialog.form.elements;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.dialog.form.SlackFormElementTypes;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionGroupIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionGroupIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.dialog.form.elements;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Strings;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/dialog/form/elements/SlackFormOptionIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.dialog.form.elements;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.base.Strings;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/AbstractSlackEventBotMessage.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/AbstractSlackEventBotMessage.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.events;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/AbstractSlackEventMessage.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/AbstractSlackEventMessage.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.events;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/AbstractSlackEventMessageChanged.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/AbstractSlackEventMessageChanged.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.events;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/AbstractSlackEventMessageDeleted.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/AbstractSlackEventMessageDeleted.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.events;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/AbstractSlackEventMessageIm.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/AbstractSlackEventMessageIm.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.events;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/AbstractSlackEventMessageReplied.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/AbstractSlackEventMessageReplied.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.events;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.events.util.SlackReplyMessage;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventSkeletonIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventSkeletonIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.events;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventWrapperIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventWrapperIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.events;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.List;
@@ -12,11 +12,18 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface SlackEventWrapperIF<T extends SlackEvent> {
   String getToken();
+
   String getTeamId();
+
   Optional<String> getContextTeamId();
+
   SlackEventType getType();
+
   List<String> getAuthedUsers();
+
   String getEventId();
+
   String getEventTime();
+
   T getEvent();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/app/SlackAppUninstalledEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/app/SlackAppUninstalledEventIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.events.app;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -9,7 +9,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackAppUninstalledEvent.class)
 public interface SlackAppUninstalledEventIF extends SlackEvent {
   //App uninstall events do not have a ts, so we manually set it as null

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/app/SlackTokensRevokedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/app/SlackTokensRevokedEventIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.events.app;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -10,7 +10,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackTokensRevokedEvent.class)
 public interface SlackTokensRevokedEventIF extends SlackEvent {
   @JsonProperty

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/app/TokensRevokedIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/app/TokensRevokedIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.events.app;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -10,7 +10,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonDeserialize(as = TokensRevoked.class)
 public interface TokensRevokedIF {
   @JsonProperty

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/bot/SlackAppHomeOpenedEventIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.events.bot;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -13,7 +13,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackAppHomeOpenedEvent.class)
 public interface SlackAppHomeOpenedEventIF extends SlackEvent, HasUser {
   Optional<String> getTab();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelArchiveEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelArchiveEventIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.events.channel;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelCreatedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelCreatedEventIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.events.channel;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelDeletedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelDeletedEventIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.events.channel;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelRenameEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelRenameEventIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.events.channel;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelUnarchiveEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/channel/SlackChannelUnarchiveEventIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.events.channel;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupArchiveEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupArchiveEventIF.java
@@ -1,13 +1,13 @@
 package com.hubspot.slack.client.models.events.group;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.events.conversation.SlackConversationEventCore;
 import org.immutables.value.Value;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackGroupArchiveEvent.class)
 @Value.Immutable
 @HubSpotStyle

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupDeletedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupDeletedEventIF.java
@@ -1,13 +1,13 @@
 package com.hubspot.slack.client.models.events.group;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.events.conversation.SlackConversationEventCore;
 import org.immutables.value.Value;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackGroupDeletedEvent.class)
 @Value.Immutable
 @HubSpotStyle

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupOpenEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupOpenEventIF.java
@@ -1,14 +1,14 @@
 package com.hubspot.slack.client.models.events.group;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.events.conversation.SlackConversationEventCore;
 import org.immutables.value.Value;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackGroupOpenEvent.class)
 @Value.Immutable
 @HubSpotStyle

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupRenameEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupRenameEventIF.java
@@ -1,13 +1,13 @@
 package com.hubspot.slack.client.models.events.group;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.events.conversation.SlackConversationEventWithChannel;
 import org.immutables.value.Value;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackGroupRenameEvent.class)
 @Value.Immutable
 @HubSpotStyle

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupUnarchiveEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/group/SlackGroupUnarchiveEventIF.java
@@ -1,13 +1,13 @@
 package com.hubspot.slack.client.models.events.group;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.events.conversation.SlackConversationEventCore;
 import org.immutables.value.Value;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackGroupUnarchiveEvent.class)
 @Value.Immutable
 @HubSpotStyle

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/links/SlackLinkSharedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/links/SlackLinkSharedEventIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.events.links;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/user/SlackMemberJoinedChannelEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/user/SlackMemberJoinedChannelEventIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.events.user;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/user/SlackMemberLeftChannelEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/user/SlackMemberLeftChannelEventIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.events.user;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/user/SlackUserChangeEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/user/SlackUserChangeEventIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.events.user;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/util/AbstractSlackReplyMessage.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/util/AbstractSlackReplyMessage.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.events.util;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.interceptor.HasUser;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackAccessDeniedFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackAccessDeniedFileIF.java
@@ -1,12 +1,9 @@
 package com.hubspot.slack.client.models.files;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
-import java.util.List;
-import java.util.Optional;
-import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 
 @Immutable

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackCsvFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackCsvFileIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.files;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileDeletedFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileDeletedFileIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.files;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileNotFoundFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileNotFoundFileIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.files;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileTombstoneIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileTombstoneIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.files;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -8,7 +8,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackFileTombstone.class)
 public interface SlackFileTombstoneIF extends SlackFileError {
   @Override

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackGifFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackGifFileIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.files;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackJavaScriptFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackJavaScriptFileIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.files;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackJpgFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackJpgFileIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.files;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -8,7 +8,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackJpgFile.class)
 public interface SlackJpgFileIF extends SlackImageFile {
   @Value.Default

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackPngFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackPngFileIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.files;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -8,7 +8,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonDeserialize(as = SlackPngFile.class)
 public interface SlackPngFileIF extends SlackImageFile {
   @Value.Default

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackTextFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackTextFileIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.files;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackUnknownFiletypeIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackUnknownFiletypeIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.files;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackXlsFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackXlsFileIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.files;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackXlsxFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackXlsxFileIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.files;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/json/SlackFileDeserializer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/json/SlackFileDeserializer.java
@@ -24,19 +24,19 @@ public class SlackFileDeserializer extends StdDeserializer<SlackFile> {
 
   private static final String FILE_ACCESS_FIELD = "file_access";
   private static final String FILE_TYPE_FIELD = "filetype";
-  private static final Map<String, Class<? extends SlackFileError>> fileTypeErrorClasses;
+  private static final Map<String, Class<? extends SlackFileError>> FILE_TYPE_ERROR_CLASSES;
 
   static {
-    fileTypeErrorClasses = new HashMap<>();
-    fileTypeErrorClasses.put(
+    FILE_TYPE_ERROR_CLASSES = new HashMap<>();
+    FILE_TYPE_ERROR_CLASSES.put(
       SlackErrorType.ACCESS_DENIED.getCode(),
       SlackAccessDeniedFile.class
     );
-    fileTypeErrorClasses.put(
+    FILE_TYPE_ERROR_CLASSES.put(
       SlackErrorType.FILE_NOT_FOUND.getCode(),
       SlackFileNotFoundFile.class
     );
-    fileTypeErrorClasses.put(
+    FILE_TYPE_ERROR_CLASSES.put(
       SlackErrorType.FILE_DELETED.getCode(),
       SlackFileDeletedFile.class
     );
@@ -55,7 +55,7 @@ public class SlackFileDeserializer extends StdDeserializer<SlackFile> {
     if (node.has(FILE_ACCESS_FIELD)) {
       String fileAccess = node.get(FILE_ACCESS_FIELD).asText();
       Optional<? extends Class<? extends SlackFileError>> errorClass =
-        Optional.ofNullable(fileTypeErrorClasses.get(fileAccess.toLowerCase()));
+        Optional.ofNullable(FILE_TYPE_ERROR_CLASSES.get(fileAccess.toLowerCase()));
       if (errorClass.isPresent()) {
         return codec.treeToValue(node, errorClass.get());
       }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlockActionsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlockActionsIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.models.interaction;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.LiteMessage;
@@ -18,8 +18,11 @@ import org.immutables.value.Value.Immutable;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface BlockActionsIF extends SlackInteractiveCallback {
   String getTriggerId();
+
   Optional<String> getResponseUrl();
+
   Optional<LiteMessage> getMessage();
+
   Optional<ViewResponseBase> getView();
 
   @JsonProperty("actions")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlockElementActionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlockElementActionIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.interaction;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -20,6 +20,7 @@ import org.immutables.value.Value.Immutable;
 @JsonSerialize(using = BlockElementActionSerializer.class)
 public interface BlockElementActionIF {
   String getBlockId();
+
   String getActionId();
 
   BlockElement getElement();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlocksLoadOptionsRequestIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlocksLoadOptionsRequestIF.java
@@ -1,11 +1,10 @@
 package com.hubspot.slack.client.models.interaction;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.views.ViewResponseBase;
 import com.hubspot.slack.client.models.teams.SlackTeam;
-import com.hubspot.slack.client.models.users.SlackUser;
 import com.hubspot.slack.client.models.users.SlackUserLite;
 import java.util.Optional;
 import org.immutables.value.Value.Immutable;
@@ -15,11 +14,17 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface BlocksLoadOptionsRequestIF {
   String getType();
+
   SlackUserLite getUser();
+
   SlackTeam getTeam();
+
   String getToken();
+
   String getActionId();
+
   String getBlockId();
+
   String getValue();
 
   Container getContainer();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlocksLoadOptionsResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/BlocksLoadOptionsResponseIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.models.interaction;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.BaseSlackOptionsResponse;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/DialogSubmissionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/DialogSubmissionIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.interaction;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Map;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/InteractiveActionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/InteractiveActionIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.interaction;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.LiteMessage;
@@ -24,6 +24,8 @@ public interface InteractiveActionIF extends SlackInteractiveCallback {
   boolean isAppUnfurl();
 
   Optional<LiteMessage> getOriginalMessage();
+
   String getResponseUrl();
+
   String getTriggerId();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/InteractiveLoadOptionsRequestIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/InteractiveLoadOptionsRequestIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.interaction;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.SlackChannel;
@@ -14,15 +14,24 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface InteractiveLoadOptionsRequestIF {
   String getName();
+
   String getValue();
+
   String getCallbackId();
+
   SlackTeam getTeam();
+
   SlackChannel getChannel();
+
   SlackUserLite getUser();
+
   InteractiveLoadOptionsRequestType getType();
 
   String getActionTs();
+
   Optional<String> getMessageTs();
+
   Optional<String> getAttachmentId();
+
   String getToken();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/MessageActionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/MessageActionIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.interaction;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.LiteMessage;
@@ -11,8 +11,12 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface MessageActionIF extends SlackInteractiveCallback {
   String getActionTs();
+
   String getCallbackId();
+
   String getTriggerId();
+
   String getResponseUrl();
+
   LiteMessage getMessage();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/MessageContainerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/MessageContainerIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.interaction;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Immutable;
@@ -11,6 +11,7 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface MessageContainerIF extends Container {
   String getMessageTs();
+
   String getChannelId();
 
   @JsonProperty("is_ephemeral")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ShortcutIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ShortcutIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.interaction;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.SlackChannel;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/StateValuesPayloadIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/StateValuesPayloadIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.interaction;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.interaction.views.ViewInput;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/TopLevelMessageInteractionResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/TopLevelMessageInteractionResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.interaction;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.Attachment;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ViewClosedIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ViewClosedIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.interaction;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.views.ViewPayloadBase;
@@ -11,5 +11,6 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ViewClosedIF extends SlackInteractiveCallback {
   ViewPayloadBase getView();
+
   boolean getIsCleared();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ViewContainerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ViewContainerIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.interaction;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Immutable;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ViewInteractionPayloadIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ViewInteractionPayloadIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.interaction;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.views.ViewPayloadBase;
@@ -11,5 +11,6 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ViewInteractionPayloadIF extends ViewPayloadBase {
   StateValuesPayload getState();
+
   String getHash();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ViewResponseActionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ViewResponseActionIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.models.interaction;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.views.ModalViewPayload;
@@ -12,7 +12,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface ViewResponseActionIF {
   @JsonProperty
   String getResponseAction();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ViewStateValuesBlockIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ViewStateValuesBlockIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.interaction;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value.Immutable;
@@ -10,5 +10,6 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ViewStateValuesBlockIF {
   String getType();
+
   String getValue();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ViewSubmissionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/ViewSubmissionIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.interaction;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.SlackChannel;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/json/BlockElementActionSerializer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/json/BlockElementActionSerializer.java
@@ -45,11 +45,13 @@ public class BlockElementActionSerializer extends StdSerializer<BlockElementActi
   ) throws IOException {
     JavaType javaType = provider.constructType(element.getClass());
     BeanDescription beanDesc = provider.getConfig().introspect(javaType);
-    JsonSerializer<Object> serializer = BeanSerializerFactory.instance.findBeanSerializer(
-      provider,
-      javaType,
-      beanDesc
-    );
+    JsonSerializer<Object> serializer =
+      BeanSerializerFactory.instance.findBeanOrAddOnSerializer(
+        provider,
+        javaType,
+        beanDesc,
+        false
+      );
     serializer.unwrappingSerializer(null).serialize(element, gen, provider);
   }
 

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/UsersSelectInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/UsersSelectInputIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.interaction.views;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewCheckboxesIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewCheckboxesIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.interaction.views;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -11,7 +11,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface ViewCheckboxesIF extends ViewInput {
   @JsonDeserialize(contentUsing = OptionOrOptionGroupDeserializer.class)
   List<Option> getSelectedOptions();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewConversationsSelectIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewConversationsSelectIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.interaction.views;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewDatePickerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewDatePickerIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.interaction.views;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.time.LocalDate;
@@ -9,7 +9,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface ViewDatePickerIF extends ViewInput {
   Optional<LocalDate> getSelectedDate();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewDateTimePickerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewDateTimePickerIF.java
@@ -1,15 +1,14 @@
 package com.hubspot.slack.client.models.interaction.views;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
-import java.time.LocalDate;
 import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface ViewDateTimePickerIF extends ViewInput {
   Optional<Integer> getSelectedDateTime();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewEmailInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewEmailInputIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.interaction.views;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewExternalSelectIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewExternalSelectIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.interaction.views;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.objects.Option;
@@ -10,7 +10,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface ViewExternalSelectIF extends ViewInput {
   Optional<Option> getSelectedOption();
 

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewInput.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewInput.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.util.Optional;
 

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewMultiExternalSelectIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewMultiExternalSelectIF.java
@@ -1,11 +1,11 @@
 package com.hubspot.slack.client.models.interaction.views;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface ViewMultiExternalSelectIF extends ViewMultiSelect {}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewMultiStaticSelectIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewMultiStaticSelectIF.java
@@ -1,11 +1,11 @@
 package com.hubspot.slack.client.models.interaction.views;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface ViewMultiStaticSelectIF extends ViewMultiSelect {}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewNumberInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewNumberInputIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.interaction.views;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewPlainTextInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewPlainTextInputIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.interaction.views;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewRadioButtonGroupIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewRadioButtonGroupIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.interaction.views;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -12,7 +12,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface ViewRadioButtonGroupIF extends ViewInput {
   @JsonDeserialize(contentUsing = OptionOrOptionGroupDeserializer.class)
   Optional<Option> getSelectedOption();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewStaticSelectIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewStaticSelectIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.interaction.views;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.objects.Option;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewTimePickerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewTimePickerIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.interaction.views;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.time.LocalTime;
@@ -9,7 +9,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface ViewTimePickerIF extends ViewInput {
   Optional<LocalTime> getSelectedTime();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewUrlInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewUrlInputIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.interaction.views;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/ResponseMetadataIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/ResponseMetadataIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/auth/AuthTestResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/auth/AuthTestResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.auth;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;
@@ -12,8 +12,12 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface AuthTestResponseIF extends SlackResponse {
   String getUrl();
+
   String getTeam();
+
   String getTeamId();
+
   Optional<String> getUser();
+
   Optional<String> getUserId();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/channels/AbstractChannelsHistoryResponse.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/channels/AbstractChannelsHistoryResponse.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.response.channels;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.methods.TimeIntervalFilter;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/channels/ChannelsKickResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/channels/ChannelsKickResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.channels;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/channels/ChannelsListResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/channels/ChannelsListResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.channels;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.SlackChannel;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/ChatDeleteResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/ChatDeleteResponseIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.response.chat;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/ChatGetPermalinkResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/ChatGetPermalinkResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.chat;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;
@@ -11,5 +11,6 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ChatGetPermalinkResponseIF extends SlackResponse {
   String getChannel();
+
   String getPermalink();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/ChatPostEphemeralMessageResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/ChatPostEphemeralMessageResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.chat;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/ChatPostMessageResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/ChatPostMessageResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.chat;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;
@@ -12,6 +12,8 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ChatPostMessageResponseIF extends SlackResponse {
   String getTs();
+
   String getChannel();
+
   Map<String, Object> getMessage();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/ChatScheduleMessageResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/ChatScheduleMessageResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.chat;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;
@@ -12,7 +12,10 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ChatScheduleMessageResponseIF extends SlackResponse {
   String getChannel();
+
   String getScheduledMessageId();
+
   String getPostAt();
+
   Map<String, Object> getMessage();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/ChatScheduledMessagesListResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/ChatScheduledMessagesListResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.chat;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.ScheduledMessage;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/ChatUnfurlResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/ChatUnfurlResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.chat;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/ChatUpdateMessageResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/ChatUpdateMessageResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.chat;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;
@@ -11,6 +11,8 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ChatUpdateMessageResponseIF extends SlackResponse {
   String getTs();
+
   String getChannel();
+
   String getText();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/conversations/ConversationListResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/conversations/ConversationListResponseIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.response.conversations;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.conversations.Conversation;
@@ -13,6 +13,7 @@ import org.immutables.value.Value.Immutable;
 @HubSpotStyle
 @JsonNaming(SnakeCaseStrategy.class)
 public interface ConversationListResponseIF extends SlackResponse {
-  @JsonProperty("channels") // just. wow.
+  @JsonProperty("channels")
+  // just. wow.
   List<Conversation> getConversations();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/conversations/ConversationsCreateResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/conversations/ConversationsCreateResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.conversations;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.SlackChannel;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/conversations/ConversationsHistoryResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/conversations/ConversationsHistoryResponseIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.response.conversations;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.LiteMessage;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/conversations/ConversationsHistoryResponseMetadataIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/conversations/ConversationsHistoryResponseMetadataIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.conversations;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/conversations/ConversationsRepliesResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/conversations/ConversationsRepliesResponseIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.response.conversations;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.LiteMessage;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/dialog/DialogOpenResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/dialog/DialogOpenResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.dialog;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/dnd/DndInfoResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/dnd/DndInfoResponseIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.models.response.dnd;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -16,7 +16,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface DndInfoResponseIF extends SlackResponse {
   boolean isDndEnabled();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/dnd/DndSnoozeResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/dnd/DndSnoozeResponseIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.models.response.dnd;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -16,7 +16,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface DndSnoozeResponseIF extends SlackResponse {
   boolean isSnoozeEnabled();

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/files/FilesSharedPublicUrlResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/files/FilesSharedPublicUrlResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.files;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.files.SlackFile;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/files/FilesUploadResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/files/FilesUploadResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.files;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.files.SlackFile;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/group/GroupsKickResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/group/GroupsKickResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.group;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/group/GroupsListResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/group/GroupsListResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.group;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.group.SlackGroup;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/im/ImOpenResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/im/ImOpenResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.im;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.channel.ImChannel;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/migration/MigrationExchangeResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/migration/MigrationExchangeResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.migration;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/usergroups/UsergroupCreateResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/usergroups/UsergroupCreateResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.usergroups;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/usergroups/UsergroupDisableResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/usergroups/UsergroupDisableResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.usergroups;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/usergroups/UsergroupEnableResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/usergroups/UsergroupEnableResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.usergroups;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/usergroups/UsergroupListResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/usergroups/UsergroupListResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.usergroups;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/usergroups/UsergroupUpdateResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/usergroups/UsergroupUpdateResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.usergroups;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/users/UsersListResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/users/UsersListResponseIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.users;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/views/HomeTabViewCommandResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/views/HomeTabViewCommandResponseIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.response.views;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/views/HomeTabViewResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/views/HomeTabViewResponseIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.response.views;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.views.HomeTabViewPayloadBase;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/views/ModalViewCommandResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/views/ModalViewCommandResponseIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.response.views;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.response.SlackResponse;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/views/ModalViewResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/views/ModalViewResponseIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.response.views;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.views.ModalViewPayloadBase;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/views/StateActionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/views/StateActionIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.response.views;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Map;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/views/StateActionValueIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/views/StateActionValueIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.response.views;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/views/StateBlockIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/views/StateBlockIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.response.views;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Map;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/teams/SlackTeamIconIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/teams/SlackTeamIconIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.teams;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/usergroups/SlackUsergroupIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/usergroups/SlackUsergroupIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.usergroups;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.List;
@@ -14,13 +14,16 @@ import org.immutables.value.Value.Immutable;
 @JsonNaming(SnakeCaseStrategy.class)
 public interface SlackUsergroupIF {
   String getId();
+
   String getTeamId();
 
   @JsonProperty("is_usergroup")
   boolean isUsergroup();
 
   String getName();
+
   Optional<String> getDescription();
+
   String getHandle();
 
   @JsonProperty("is_external")
@@ -36,8 +39,11 @@ public interface SlackUsergroupIF {
   int getDateDeletedEpochSeconds(); // 0 means never
 
   Optional<String> getAutoType();
+
   Optional<String> getCreatedBy();
+
   Optional<String> getUpdatedBy();
+
   Optional<String> getDeletedBy();
 
   @Derived

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/usergroups/UsergroupPreferencesIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/usergroups/UsergroupPreferencesIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.usergroups;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.List;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/users/SlackUserIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/users/SlackUserIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.users;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;
@@ -18,12 +18,19 @@ public interface SlackUserIF extends SlackUserCore {
   Optional<Boolean> isDeleted();
 
   Optional<String> getColor();
+
   Optional<String> isAdmin();
+
   Optional<String> isOwner();
+
   Optional<String> getTeamId();
+
   Optional<String> getRealName();
+
   Optional<Boolean> isPrimaryOwner();
+
   Optional<Boolean> isRestricted();
+
   Optional<Boolean> isUltraRestricted();
 
   @JsonProperty("is_bot")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/users/SlackUserLiteIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/users/SlackUserLiteIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.users;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import java.util.Optional;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/users/UserProfileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/users/UserProfileIF.java
@@ -2,7 +2,7 @@ package com.hubspot.slack.client.models.users;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -23,13 +23,21 @@ public interface UserProfileIF {
   Optional<String> getUsernameNormalized();
 
   Optional<String> getRealName();
+
   Optional<String> getRealNameNormalized();
+
   Optional<String> getEmail();
+
   Optional<String> getStatusText();
+
   Optional<String> getStatusEmoji();
+
   Optional<Long> getStatusExpiration();
+
   Optional<String> getTitle();
+
   Optional<String> getPhone();
+
   Optional<String> getSkype();
 
   // Extra custom fields set by your workspace admin
@@ -40,6 +48,7 @@ public interface UserProfileIF {
   Optional<String> getTeamId();
 
   Optional<String> getAvatarHash();
+
   Optional<String> getImageOriginal();
 
   @JsonProperty("image_24")

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/views/HomeTabViewPayloadIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/views/HomeTabViewPayloadIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.slack.client.models.views;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.Block;
@@ -10,7 +10,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface HomeTabViewPayloadIF
   extends HomeTabViewPayloadBase, ViewPayloadJsonBase {

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/views/ModalViewPayloadIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/views/ModalViewPayloadIF.java
@@ -1,6 +1,6 @@
 package com.hubspot.slack.client.models.views;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.Block;
@@ -10,7 +10,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface ModalViewPayloadIF extends ModalViewPayloadBase, ViewPayloadJsonBase {
   @Override
   @Value.Parameter

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/FollowThreadsMixin.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/concurrency/FollowThreadsMixin.java
@@ -42,7 +42,8 @@ public interface FollowThreadsMixin {
       try {
         voidCallable.call();
       } catch (Exception e) {
-        throw Throwables.propagate(e);
+        Throwables.throwIfUnchecked(e);
+        throw new RuntimeException(e);
       }
     };
   }

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/paging/AbstractPagedIterator.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/paging/AbstractPagedIterator.java
@@ -29,7 +29,8 @@ public abstract class AbstractPagedIterator<T, K>
 
       return endOfData();
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      Throwables.throwIfUnchecked(e);
+      throw new RuntimeException(e);
     }
   }
 


### PR DESCRIPTION
Changes related to jackson dependency update:

* replace use of deprecated `com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy` with `com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy`
* clean up uses of `BeanSerializerFactory::findBeanSerializer`

