### PR TITLE
Add support for deserializing Slack Connect files

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackConnectFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackConnectFileIF.java
@@ -1,0 +1,13 @@
+package com.hubspot.slack.client.models.files;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value.Immutable;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackConnectFile.class)
+public interface SlackConnectFileIF extends SlackFileError {}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/json/SlackFileDeserializer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/json/SlackFileDeserializer.java
@@ -1,13 +1,13 @@
 package com.hubspot.slack.client.models.files.json;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.hubspot.slack.client.models.files.SlackAccessDeniedFile;
+import com.hubspot.slack.client.models.files.SlackConnectFile;
 import com.hubspot.slack.client.models.files.SlackFile;
 import com.hubspot.slack.client.models.files.SlackFileDeletedFile;
 import com.hubspot.slack.client.models.files.SlackFileError;
@@ -26,6 +26,7 @@ public class SlackFileDeserializer extends StdDeserializer<SlackFile> {
   private static final String FILE_ACCESS_FIELD = "file_access";
   private static final String FILE_MODE_FIELD = "mode";
   private static final String FILE_TYPE_FIELD = "filetype";
+  private static final String SLACK_CONNECT_FILE_ACCESS = "check_file_info";
   private static final Map<String, Class<? extends SlackFileError>> FILE_TYPE_ERROR_CLASSES;
 
   static {
@@ -42,6 +43,7 @@ public class SlackFileDeserializer extends StdDeserializer<SlackFile> {
       SlackErrorType.FILE_DELETED.getCode(),
       SlackFileDeletedFile.class
     );
+    FILE_TYPE_ERROR_CLASSES.put(SLACK_CONNECT_FILE_ACCESS, SlackConnectFile.class);
   }
 
   public SlackFileDeserializer() {
@@ -50,7 +52,7 @@ public class SlackFileDeserializer extends StdDeserializer<SlackFile> {
 
   @Override
   public SlackFile deserialize(JsonParser p, DeserializationContext ctxt)
-    throws IOException, JsonProcessingException {
+    throws IOException {
     ObjectCodec codec = p.getCodec();
     JsonNode node = codec.readTree(p);
 

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/files/SlackFileDeserializerTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/files/SlackFileDeserializerTest.java
@@ -67,6 +67,14 @@ public class SlackFileDeserializerTest {
     assertEquals("F0S43PZDF", file.getId());
   }
 
+  @Test
+  public void shouldDeserializeSlackConnectFile() throws IOException {
+    SlackFile file = fetchAndDeserializeSlackFile("file_slack_connect.json");
+    assertEquals(SlackFileType.UNKNOWN, file.getFiletype());
+    assertTrue(file instanceof SlackConnectFile);
+    assertEquals("F12345678", file.getId());
+  }
+
   private SlackFile fetchAndDeserializeSlackFile(String jsonFileName) throws IOException {
     String rawJson = JsonLoader.loadJsonFromFile(jsonFileName);
     return ObjectMapperUtils.mapper().readValue(rawJson, SlackFile.class);

--- a/slack-base/src/test/resources/file_slack_connect.json
+++ b/slack-base/src/test/resources/file_slack_connect.json
@@ -1,0 +1,8 @@
+{
+  "id": "F12345678",
+  "mode": "file_access",
+  "file_access": "check_file_info",
+  "created": 0,
+  "timestamp": 0,
+  "user": ""
+}


### PR DESCRIPTION
The current SlackFileDeserializer doesn't handle Slack Connect files, which are described [here in the docs](https://api.slack.com/events/message/file_share#slack_connect_files). This change adds support for these files.