### PR TITLE
Add slack file object to image block

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ImageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ImageIF.java
@@ -28,4 +28,5 @@ public interface ImageIF extends Block, ImageBlockOrText {
   String getAltText();
 
   Optional<Text> getTitle();
+  Optional<SlackFileObject> getSlackFile();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SlackFileObjectIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SlackFileObjectIF.java
@@ -1,0 +1,15 @@
+package com.hubspot.slack.client.models.blocks;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public interface SlackFileObjectIF {
+  Optional<String> getUrl();
+  Optional<String> getId();
+}


### PR DESCRIPTION
This adds support for the `slack_file` type in image blocks (docs [here](https://api.slack.com/reference/block-kit/composition-objects#slack_file)). This should allow usage of blocks that were uploaded using the [files API](https://api.slack.com/methods/files.getUploadURLExternal#markdown).