### PR TITLE
Add NOT_IN_CHANNEL Slack error type

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/SlackErrorType.java
@@ -95,6 +95,7 @@ public enum SlackErrorType {
   JSON_PARSING_FAILED("_json_parsing_failed"),
   WRITE_RESTRICTED_TO_PROD("_write_restricted_to_prod"),
   PARAMS_FAILED_API_FILTER("_method_failed_filter"),
+  NOT_IN_CHANNEL("not_in_channel"),
   UNKNOWN("unknown");
 
   private final String code;


### PR DESCRIPTION
[not_in_channel](https://api.slack.com/methods/conversations.history#:~:text=The%20token%20used%20does%20not%20have%20access%20to%20the%20proper%20channel.%20Only%20user%20tokens%20can%20access%20public%20channels%20they%20are%20not%20in.) is one of the errors returned by Slack API. 
Need to have it to determine the reason why bot failed to set reaction to message sent by user. In such case we are going to show descriptive error message.