### PR TITLE
Make url optional

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ImageIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/ImageIF.java
@@ -22,7 +22,7 @@ public interface ImageIF extends Block, ImageBlockOrText {
   }
 
   @Value.Parameter
-  String getImageUrl();
+  Optional<String> getImageUrl();
 
   @Value.Parameter
   String getAltText();


### PR DESCRIPTION
Image url is optional, according to [these docs](https://api.slack.com/reference/block-kit/blocks#image_fields).