### PR TITLE
Fix json serialization for slack_files

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SlackFileObjectIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SlackFileObjectIF.java
@@ -1,5 +1,6 @@
 package com.hubspot.slack.client.models.blocks;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -9,6 +10,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @HubSpotStyle
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public interface SlackFileObjectIF {
   Optional<String> getUrl();
   Optional<String> getId();


### PR DESCRIPTION
Missed this in https://github.com/HubSpot/slack-client/pull/358. This is needed so that only one of these two fields is serialized to json. If only one is present but both are serialized, it results in a "cannot parse attachment" error. [Docs here](https://api.slack.com/reference/block-kit/composition-objects#slack_file).