### PR TITLE
Add explict serializer and deserializer behaviour for is* getters

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/DateTimePickerIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/DateTimePickerIF.java
@@ -1,6 +1,7 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -32,5 +33,7 @@ public interface DateTimePickerIF extends BlockElement, HasActionId {
   @JsonProperty("confirm")
   Optional<ConfirmationDialog> getConfirmationDialog();
 
+  @JsonSetter("focus_on_load")
+  @JsonProperty("is_focus_on_load")
   Optional<Boolean> isFocusOnLoad();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/EmailInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/EmailInputIF.java
@@ -2,6 +2,8 @@ package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;
 import com.hubspot.slack.client.models.blocks.objects.Text;
@@ -29,6 +31,8 @@ public interface EmailInputIF extends BlockElement, HasActionId {
 
   Optional<String> getInitialValue();
 
+  @JsonSetter("focus_on_load")
+  @JsonProperty("is_focus_on_load")
   Optional<Boolean> isFocusOnLoad();
 
   @Check

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/EmailInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/EmailInputIF.java
@@ -1,9 +1,9 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;
 import com.hubspot.slack.client.models.blocks.objects.Text;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/NumberInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/NumberInputIF.java
@@ -3,6 +3,8 @@ package com.hubspot.slack.client.models.blocks.elements;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;
 import com.hubspot.slack.client.models.blocks.objects.Text;
@@ -38,6 +40,8 @@ public interface NumberInputIF extends BlockElement, HasActionId {
 
   Optional<String> getMaxValue();
 
+  @JsonSetter("focus_on_load")
+  @JsonProperty("is_focus_on_load")
   Optional<Boolean> isFocusOnLoad();
 
   @Check

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/NumberInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/NumberInputIF.java
@@ -1,10 +1,10 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;
 import com.hubspot.slack.client.models.blocks.objects.Text;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/NumberInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/NumberInputIF.java
@@ -1,7 +1,6 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UrlInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UrlInputIF.java
@@ -1,9 +1,9 @@
 package com.hubspot.slack.client.models.blocks.elements;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;
 import com.hubspot.slack.client.models.blocks.objects.Text;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UrlInputIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/UrlInputIF.java
@@ -2,6 +2,8 @@ package com.hubspot.slack.client.models.blocks.elements;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.slack.client.models.blocks.SlackBlockNormalizer;
 import com.hubspot.slack.client.models.blocks.objects.Text;
@@ -29,6 +31,8 @@ public interface UrlInputIF extends BlockElement, HasActionId {
 
   Optional<String> getInitialValue();
 
+  @JsonSetter("focus_on_load")
+  @JsonProperty("is_focus_on_load")
   Optional<Boolean> isFocusOnLoad();
 
   @Check

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/users/SlackUserIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/users/SlackUserIF.java
@@ -1,6 +1,7 @@
 package com.hubspot.slack.client.models.users;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/users/SlackUserIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/users/SlackUserIF.java
@@ -27,15 +27,23 @@ public interface SlackUserIF extends SlackUserCore {
 
   Optional<String> getRealName();
 
+  @JsonSetter("primaryOwner")
+  @JsonProperty("is_primary_owner")
   Optional<Boolean> isPrimaryOwner();
 
+  @JsonSetter("restricted")
+  @JsonProperty("is_restricted")
   Optional<Boolean> isRestricted();
 
+  @JsonSetter("ultra_restricted")
+  @JsonProperty("is_ultra_restricted")
   Optional<Boolean> isUltraRestricted();
 
   @JsonProperty("is_bot")
   Optional<Boolean> isBot();
 
+  @JsonSetter("app_user")
+  @JsonProperty("is_app_user")
   Optional<Boolean> isAppUser();
 
   @JsonProperty("tz")


### PR DESCRIPTION
Jackson serializes/deserializes getters with is* prefixes for Optional boolean values inconsistently across the versions Jackson. This will explictly add the de/serialization behaviour so that we can safely upgrade Jackson versions.

