### PR TITLE
add zip filetype

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackFileType.java
@@ -15,6 +15,7 @@ public enum SlackFileType {
   XLSX("xlsx", SlackXlsxFile.class),
   XLS("xls", SlackXlsFile.class),
   GDOC("gdoc", SlackGdocFile.class),
+  ZIP("zip", SlackZipFile.class),
   UNKNOWN("unknown", SlackUnknownFiletype.class);
 
   final String type;

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackZipFileIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/files/SlackZipFileIF.java
@@ -1,0 +1,20 @@
+package com.hubspot.slack.client.models.files;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Immutable;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackGdocFile.class)
+public interface SlackZipFileIF extends SlackFile {
+  @Default
+  @Override
+  default SlackFileType getFiletype() {
+    return SlackFileType.ZIP;
+  }
+}


### PR DESCRIPTION
Add 'zip' filetype to the file type enum to handle zip files.

This PR is to resolve the same issue as the PR below does
https://github.com/HubSpot/slack-client/pull/364