### PR TITLE
Add multi users select input

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewInput.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewInput.java
@@ -34,6 +34,7 @@ import java.util.Optional;
     @Type(value = ViewExternalSelect.class, name = "external_select"),
     @Type(value = ViewMultiStaticSelect.class, name = "multi_static_select"),
     @Type(value = ViewMultiExternalSelect.class, name = "multi_external_select"),
+    @Type(value = ViewMultiUsersSelect.class, name = "multi_users_select"),
   }
 )
 public interface ViewInput {

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewInputType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewInputType.java
@@ -20,6 +20,7 @@ public enum ViewInputType {
   STATIC_SELECT,
   MULTI_STATIC_SELECT,
   MULTI_EXTERNAL_SELECT,
+  MULTI_USERS_SELECT,
   UNKNOWN;
 
   private static final EnumIndex<String, ViewInputType> INDEX = new EnumIndex<>(

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewMultiUsersSelectIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/interaction/views/ViewMultiUsersSelectIF.java
@@ -1,0 +1,22 @@
+package com.hubspot.slack.client.models.interaction.views;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import java.util.List;
+import java.util.Optional;
+import org.immutables.value.Value.Immutable;
+
+@Immutable
+@HubSpotStyle
+@JsonNaming(SnakeCaseStrategy.class)
+public interface ViewMultiUsersSelectIF extends ViewInput {
+  List<String> getSelectedUsers();
+
+  @JsonIgnore
+  default Optional<String> getStringValue() {
+    List<String> users = getSelectedUsers();
+    return users.isEmpty() ? Optional.empty() : Optional.of(String.join(",", users));
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/views/ViewSubmissionDeserializationTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/views/ViewSubmissionDeserializationTest.java
@@ -11,6 +11,7 @@ import com.hubspot.slack.client.models.interaction.views.ViewInput;
 import com.hubspot.slack.client.models.interaction.views.ViewInputType;
 import com.hubspot.slack.client.models.interaction.views.ViewMultiExternalSelect;
 import com.hubspot.slack.client.models.interaction.views.ViewMultiStaticSelect;
+import com.hubspot.slack.client.models.interaction.views.ViewMultiUsersSelect;
 import com.hubspot.slack.client.testutils.TestBlocksBuilder;
 import java.io.IOException;
 import java.util.Map;
@@ -90,5 +91,17 @@ public class ViewSubmissionDeserializationTest {
     final ViewMultiExternalSelect multiExternalSelect = (ViewMultiExternalSelect) input;
     assertThat(multiExternalSelect.getSelectedOptions())
       .containsExactly(option, anotherOption);
+  }
+
+  @Test
+  public void itDeserializesMultiUsersSelect() {
+    ViewInput input = BLOCK_ID_TO_ACTION_ID_TO_VALUES
+      .get("MuS")
+      .get("multi_users_select-action");
+    assertThat(input.getType()).isEqualTo(ViewInputType.MULTI_USERS_SELECT);
+
+    final ViewMultiUsersSelect multiUsersSelect = (ViewMultiUsersSelect) input;
+    assertThat(multiUsersSelect.getSelectedUsers())
+      .containsExactly("U12345", "U67890", "U11111");
   }
 }

--- a/slack-base/src/test/resources/view_submission.json
+++ b/slack-base/src/test/resources/view_submission.json
@@ -158,6 +158,12 @@
               }
             ]
           }
+        },
+        "MuS": {
+          "multi_users_select-action": {
+            "type": "multi_users_select",
+            "selected_users": ["U12345", "U67890", "U11111"]
+          }
         }
       }
     },


### PR DESCRIPTION
Add support for the [MultiUsersSelect](https://docs.slack.dev/tools/node-slack-sdk/reference/types/interfaces/MultiUsersSelect/) input type. 

Tested locally and slack-client was able to parse values from this input type.