### PR TITLE
Feature/update fields for work object

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/entity/EntityPayloadAttributesCustomFieldIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/entity/EntityPayloadAttributesCustomFieldIF.java
@@ -1,13 +1,39 @@
 package com.hubspot.slack.client.methods.params.chat.workobject.entity;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.methods.params.chat.workobject.serializers.FieldDataTypeSerializer;
+import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface EntityPayloadAttributesCustomFieldIF {
   String getKey();
   String getLabel();
   String getValue();
-  String getType();
+
+  @JsonSerialize(using = FieldDataTypeSerializer.class)
+  FieldDataType getType();
+
+  //Can only be set when the type is string. This icon will be displayed next to field's text value. Not compatible with tag_color.
+  Optional<Icon> getIcon();
+
+  //Can only be set when the type is string, date, or timestamp. The field's content will be hyperlinked with the URL specified here
+  Optional<String> getLink();
+
+  //Can only be set when the type is string. Allows the string to be highlighted in of one of the following colors: red, yellow, green, gray, blue. E.g. tag_color: "red"
+  Optional<String> getTagColor();
+
+  //Used when the field's type is slack#/types/image.
+  Optional<String> getImageUrl();
+
+  //Used when the field's type is slack#/types/image.
+  Optional<String> getSlackFile();
+
+  //Used when the field's type is slack#/types/image.
+  Optional<String> getAltText();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/entity/EntityPayloadAttributesIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/entity/EntityPayloadAttributesIF.java
@@ -22,6 +22,6 @@ public interface EntityPayloadAttributesIF {
   Optional<DisplayType> getDisplayType();
 
   Optional<String> getProductName();
-  Optional<ProductIcon> getProductIcon();
+  Optional<Icon> getProductIcon();
   Optional<String> getLocale();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/entity/FieldDataType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/entity/FieldDataType.java
@@ -1,0 +1,23 @@
+package com.hubspot.slack.client.methods.params.chat.workobject.entity;
+
+public enum FieldDataType {
+  STRING("string"),
+  INTEGER("integer"),
+  USER_ID("slack#/types/user_id"),
+  CHANNEL_ID("slack#/types/channel_id"),
+  TIMESTAMP("slack#/types/timestamp"),
+  //A date in the format YYYY-MM-DD
+  DATE("slack#/types/date"),
+  //An image; provide either the URL of a publicly hosted image (image_url) or a slack_file with a preview image
+  IMAGE("slack#/types/image");
+
+  private final String value;
+
+  FieldDataType(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/entity/IconIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/entity/IconIF.java
@@ -8,7 +8,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @HubSpotStyle
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public interface ProductIconIF {
+public interface IconIF {
   String getUrl();
   String getAltText();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/serializers/FieldDataTypeSerializer.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/serializers/FieldDataTypeSerializer.java
@@ -1,0 +1,19 @@
+package com.hubspot.slack.client.methods.params.chat.workobject.serializers;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.hubspot.slack.client.methods.params.chat.workobject.entity.FieldDataType;
+import java.io.IOException;
+
+public class FieldDataTypeSerializer extends JsonSerializer<FieldDataType> {
+
+  @Override
+  public void serialize(
+    FieldDataType fieldDataType,
+    JsonGenerator jsonGenerator,
+    SerializerProvider serializerProvider
+  ) throws IOException {
+    jsonGenerator.writeString(fieldDataType.getValue());
+  }
+}


### PR DESCRIPTION
We, as the HubSpot Slack integration team, are working on improvements to the link unfurling logic. In this PR, we’ve added more customization for the Work Object fields

Corresponding task: https://git.hubteam.com/orgs/HubSpot/projects/1053/views/1?filterQuery=milestone%3A%22Link+unfurling+with+WorkObjects%22&pane=issue&itemId=919680