### PR TITLE
Add models to deal with Slack Work Object Flexpane and Action Buttons for it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        distribution: 'temurin'
-        java-version: '21'
+        distribution: 'adopt'
+        java-version: '11'
     - name: Build with Maven
       run: mvn -B -q clean install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        distribution: 'adopt'
-        java-version: '11'
+        distribution: 'temurin'
+        java-version: '21'
     - name: Build with Maven
       run: mvn -B -q clean install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 2
     - name: Set up JDK

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>63.9-SNAPSHOT</version>
+    <version>63.8</version>
   </parent>
 
   <groupId>com.hubspot.slack</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -105,4 +105,16 @@
       <email>jstehler@hubspot.com</email>
     </developer>
   </developers>
+
+  <profiles>
+    <profile>
+      <id>skip-spotbugs-java25</id>
+      <activation>
+        <jdk>[25,)</jdk>
+      </activation>
+      <properties>
+        <spotbugs.skip>true</spotbugs.skip>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -105,16 +105,4 @@
       <email>jstehler@hubspot.com</email>
     </developer>
   </developers>
-
-  <profiles>
-    <profile>
-      <id>skip-spotbugs-java25</id>
-      <activation>
-        <jdk>[25,)</jdk>
-      </activation>
-      <properties>
-        <spotbugs.skip>true</spotbugs.skip>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>63.4</version>
+    <version>63.7</version>
   </parent>
 
   <groupId>com.hubspot.slack</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>63.8</version>
+    <version>63.9-SNAPSHOT</version>
   </parent>
 
   <groupId>com.hubspot.slack</groupId>
@@ -27,6 +27,7 @@
   <properties>
     <horizon.version>0.1.1</horizon.version>
     <dep.netty3.version>3.10.6.Final</dep.netty3.version>
+    <dep.plugin.spotbugs.version>4.9.3.2</dep.plugin.spotbugs.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>63.7</version>
+    <version>63.8</version>
   </parent>
 
   <groupId>com.hubspot.slack</groupId>

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/SlackMethods.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/SlackMethods.java
@@ -643,7 +643,13 @@ public enum SlackMethods implements SlackMethod {
   views_open(MethodWriteMode.WRITE, RateLimitingTiers.TIER_4, JsonStatus.ACCEPTS_JSON),
   views_update(MethodWriteMode.WRITE, RateLimitingTiers.TIER_4, JsonStatus.ACCEPTS_JSON),
   views_push(MethodWriteMode.WRITE, RateLimitingTiers.TIER_4, JsonStatus.ACCEPTS_JSON),
-  views_publish(MethodWriteMode.WRITE, RateLimitingTiers.TIER_4, JsonStatus.ACCEPTS_JSON);
+  views_publish(MethodWriteMode.WRITE, RateLimitingTiers.TIER_4, JsonStatus.ACCEPTS_JSON),
+
+  entity_presentDetails(
+    MethodWriteMode.WRITE,
+    RateLimitingTiers.TIER_3,
+    JsonStatus.ACCEPTS_JSON
+  );
 
   private final MethodWriteMode writeMode;
   private final RateLimitingTier rateLimitingTier;

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/WorkObjectBase.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/WorkObjectBase.java
@@ -1,0 +1,16 @@
+package com.hubspot.slack.client.methods.params.chat.workobject;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.hubspot.slack.client.methods.params.chat.workobject.entity.EntityPayload;
+import com.hubspot.slack.client.methods.params.chat.workobject.serializers.EntityTypeSerializer;
+
+public interface WorkObjectBase {
+  @JsonSerialize(using = EntityTypeSerializer.class)
+  EntityType getEntityType();
+
+  EntityPayload getEntityPayload();
+
+  String getUrl();
+
+  ExternalRef getExternalRef();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/WorkObjectIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/WorkObjectIF.java
@@ -2,22 +2,12 @@ package com.hubspot.slack.client.methods.params.chat.workobject;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.hubspot.immutables.style.HubSpotStyle;
-import com.hubspot.slack.client.methods.params.chat.workobject.entity.EntityPayload;
-import com.hubspot.slack.client.methods.params.chat.workobject.serializers.EntityTypeSerializer;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public interface WorkObjectIF {
+public interface WorkObjectIF extends WorkObjectBase {
   String getAppUnfurlUrl();
-  String getUrl();
-  ExternalRef getExternalRef();
-
-  @JsonSerialize(using = EntityTypeSerializer.class)
-  EntityType getEntityType();
-
-  EntityPayload getEntityPayload();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/actions/WorkObjectActionBlockIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/actions/WorkObjectActionBlockIF.java
@@ -1,0 +1,15 @@
+package com.hubspot.slack.client.methods.params.chat.workobject.actions;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import java.util.List;
+import org.immutables.value.Value;
+
+@HubSpotStyle
+@Value.Immutable
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public interface WorkObjectActionBlockIF {
+  List<WorkObjectAction> getPrimaryActions();
+  List<WorkObjectAction> getOverflowActions();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/actions/WorkObjectActionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/actions/WorkObjectActionIF.java
@@ -1,0 +1,19 @@
+package com.hubspot.slack.client.methods.params.chat.workobject.actions;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@HubSpotStyle
+@Value.Immutable
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public interface WorkObjectActionIF {
+  String getText();
+  String getActionId();
+  Optional<String> getValue();
+  Optional<WorkObjectActionStyle> getStyle();
+  Optional<String> getUrl();
+  Optional<String> getAccessibilityLabel();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/actions/WorkObjectActionStyle.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/actions/WorkObjectActionStyle.java
@@ -1,0 +1,19 @@
+package com.hubspot.slack.client.methods.params.chat.workobject.actions;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum WorkObjectActionStyle {
+  PRIMARY,
+  DANGER;
+
+  @JsonCreator
+  public static WorkObjectActionStyle parse(String result) {
+    return WorkObjectActionStyle.valueOf(result.toUpperCase());
+  }
+
+  @JsonValue
+  public String value() {
+    return name().toLowerCase();
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/entity/EntityPayloadIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/entity/EntityPayloadIF.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.methods.params.chat.workobject.actions.WorkObjectActionBlock;
 import com.hubspot.slack.client.methods.params.chat.workobject.entity.fields.EntityPayloadFields;
 import java.util.List;
 import java.util.Optional;
@@ -18,4 +19,5 @@ public interface EntityPayloadIF {
   Optional<EntityPayloadFields> getFields();
   List<EntityPayloadAttributesCustomField> getCustomFields();
   List<String> getDisplayOrder();
+  WorkObjectActionBlock getActions();
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/entity/SlackEntityDetailsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/entity/SlackEntityDetailsIF.java
@@ -1,0 +1,32 @@
+package com.hubspot.slack.client.methods.params.chat.workobject.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.methods.params.chat.workobject.ExternalRef;
+import com.hubspot.slack.client.models.events.SlackEvent;
+import com.hubspot.slack.client.models.events.links.Link;
+import org.immutables.value.Value;
+
+@HubSpotStyle
+@Value.Immutable
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonDeserialize(as = SlackEntityDetails.class)
+public interface SlackEntityDetailsIF extends SlackEvent {
+  String getTriggerId();
+
+  @JsonProperty("user")
+  String getUserId();
+
+  @JsonProperty("channel")
+  String getChannelId();
+
+  String getMessageTs();
+
+  ExternalRef getExternalRef();
+
+  Link getLink();
+  String getAppUnfurlUrl();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/flexpane/FlexPaneMetadataIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/flexpane/FlexPaneMetadataIF.java
@@ -1,0 +1,12 @@
+package com.hubspot.slack.client.methods.params.chat.workobject.flexpane;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.methods.params.chat.workobject.WorkObjectBase;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public interface FlexPaneMetadataIF extends WorkObjectBase {}

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/flexpane/MessageFormat.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/flexpane/MessageFormat.java
@@ -1,0 +1,19 @@
+package com.hubspot.slack.client.methods.params.chat.workobject.flexpane;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum MessageFormat {
+  STRING,
+  MARKDOWN;
+
+  @JsonCreator
+  public static MessageFormat parse(String result) {
+    return MessageFormat.valueOf(result.toUpperCase());
+  }
+
+  @JsonValue
+  public String value() {
+    return name().toLowerCase();
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/flexpane/WorkObjectFlexpaneErrorIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/flexpane/WorkObjectFlexpaneErrorIF.java
@@ -1,0 +1,20 @@
+package com.hubspot.slack.client.methods.params.chat.workobject.flexpane;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.methods.params.chat.workobject.actions.WorkObjectAction;
+import java.util.List;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@HubSpotStyle
+@Value.Immutable
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public interface WorkObjectFlexpaneErrorIF {
+  WorkObjectFlexpaneErrorStatus getStatus();
+  Optional<String> getCustomTitle();
+  Optional<String> getCustomMessage();
+  MessageFormat getMessageFormat();
+  List<WorkObjectAction> getActions();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/flexpane/WorkObjectFlexpaneErrorStatus.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/flexpane/WorkObjectFlexpaneErrorStatus.java
@@ -1,0 +1,24 @@
+package com.hubspot.slack.client.methods.params.chat.workobject.flexpane;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum WorkObjectFlexpaneErrorStatus {
+  RESTRICTED,
+  INTERNAL_ERROR,
+  NOT_FOUND,
+  CUSTOM,
+  CUSTOM_PARTIAL_VIEW,
+  TIMEOUT,
+  EDIT_ERROR;
+
+  @JsonCreator
+  public static WorkObjectFlexpaneErrorStatus parse(String result) {
+    return WorkObjectFlexpaneErrorStatus.valueOf(result.toUpperCase());
+  }
+
+  @JsonValue
+  public String value() {
+    return name().toLowerCase();
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/flexpane/WorkObjectFlexpaneParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/flexpane/WorkObjectFlexpaneParamsIF.java
@@ -1,0 +1,19 @@
+package com.hubspot.slack.client.methods.params.chat.workobject.flexpane;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.methods.params.chat.workobject.Metadata;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@HubSpotStyle
+@Value.Immutable
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public interface WorkObjectFlexpaneParamsIF {
+  String getTriggerId();
+  Metadata getMetadata();
+  Optional<Boolean> getIsUserAuthRequired();
+  Optional<String> getUserAuthUrl();
+  Optional<WorkObjectFlexpaneError> getError();
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventType.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/SlackEventType.java
@@ -3,6 +3,7 @@ package com.hubspot.slack.client.models.events;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.hubspot.slack.client.enums.EnumIndex;
+import com.hubspot.slack.client.methods.params.chat.workobject.entity.SlackEntityDetails;
 import com.hubspot.slack.client.models.events.app.SlackAppUninstalledEvent;
 import com.hubspot.slack.client.models.events.app.SlackTokensRevokedEvent;
 import com.hubspot.slack.client.models.events.assistant.SlackAssistantThreadContextChangedEvent;
@@ -69,6 +70,7 @@ public enum SlackEventType {
   IM_HISTORY_CHANGED,
   IM_OPEN,
   LINK_SHARED(SlackLinkSharedEvent.class),
+  ENTITY_PRESENT_DETAILS(SlackEntityDetails.class),
   MEMBER_JOINED_CHANNEL(SlackMemberJoinedChannelEvent.class),
   MEMBER_LEFT_CHANNEL(SlackMemberLeftChannelEvent.class),
   MESSAGE(SlackEventMessage.class),

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/events/links/EntityDetailsRequestedEventIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/events/links/EntityDetailsRequestedEventIF.java
@@ -1,0 +1,8 @@
+package com.hubspot.slack.client.models.events.links;
+
+import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
+
+@HubSpotStyle
+@Value.Immutable
+public interface EntityDetailsRequestedEventIF {}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/EntityPresentDetailsResponseIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/response/chat/EntityPresentDetailsResponseIF.java
@@ -1,0 +1,12 @@
+package com.hubspot.slack.client.models.response.chat;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.slack.client.models.response.SlackResponse;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@HubSpotStyle
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public interface EntityPresentDetailsResponseIF extends SlackResponse {}

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackClient.java
@@ -31,6 +31,7 @@ import com.hubspot.slack.client.methods.params.chat.ChatScheduleMessageParams;
 import com.hubspot.slack.client.methods.params.chat.ChatScheduledMessagesListParams;
 import com.hubspot.slack.client.methods.params.chat.ChatUnfurlParams;
 import com.hubspot.slack.client.methods.params.chat.ChatUpdateMessageParams;
+import com.hubspot.slack.client.methods.params.chat.workobject.flexpane.WorkObjectFlexpaneParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationArchiveParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationCreateParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationInviteParams;
@@ -107,6 +108,7 @@ import com.hubspot.slack.client.models.response.chat.ChatScheduleMessageResponse
 import com.hubspot.slack.client.models.response.chat.ChatScheduledMessagesListResponse;
 import com.hubspot.slack.client.models.response.chat.ChatUnfurlResponse;
 import com.hubspot.slack.client.models.response.chat.ChatUpdateMessageResponse;
+import com.hubspot.slack.client.models.response.chat.EntityPresentDetailsResponse;
 import com.hubspot.slack.client.models.response.conversations.ConversationKickResponse;
 import com.hubspot.slack.client.models.response.conversations.ConversationListResponse;
 import com.hubspot.slack.client.models.response.conversations.ConversationMemberResponse;
@@ -295,6 +297,9 @@ public interface SlackClient extends Closeable {
   );
   CompletableFuture<Result<ChatUnfurlResponse, SlackError>> unfurlLinks(
     ChatUnfurlParams params
+  );
+  CompletableFuture<Result<EntityPresentDetailsResponse, SlackError>> entityPresentDetails(
+    WorkObjectFlexpaneParams params
   );
 
   // conversations

--- a/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
+++ b/slack-java-client/src/main/java/com/hubspot/slack/client/SlackWebClient.java
@@ -62,6 +62,7 @@ import com.hubspot.slack.client.methods.params.chat.ChatScheduleMessageParams;
 import com.hubspot.slack.client.methods.params.chat.ChatScheduledMessagesListParams;
 import com.hubspot.slack.client.methods.params.chat.ChatUnfurlParams;
 import com.hubspot.slack.client.methods.params.chat.ChatUpdateMessageParams;
+import com.hubspot.slack.client.methods.params.chat.workobject.flexpane.WorkObjectFlexpaneParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationArchiveParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationCreateParams;
 import com.hubspot.slack.client.methods.params.conversations.ConversationInviteParams;
@@ -143,6 +144,7 @@ import com.hubspot.slack.client.models.response.chat.ChatScheduleMessageResponse
 import com.hubspot.slack.client.models.response.chat.ChatScheduledMessagesListResponse;
 import com.hubspot.slack.client.models.response.chat.ChatUnfurlResponse;
 import com.hubspot.slack.client.models.response.chat.ChatUpdateMessageResponse;
+import com.hubspot.slack.client.models.response.chat.EntityPresentDetailsResponse;
 import com.hubspot.slack.client.models.response.conversations.ConversationKickResponse;
 import com.hubspot.slack.client.models.response.conversations.ConversationListResponse;
 import com.hubspot.slack.client.models.response.conversations.ConversationMemberResponse;
@@ -858,6 +860,17 @@ public class SlackWebClient implements SlackClient {
     ChatUnfurlParams params
   ) {
     return postSlackCommand(SlackMethods.chat_unfurl, params, ChatUnfurlResponse.class);
+  }
+
+  @Override
+  public CompletableFuture<Result<EntityPresentDetailsResponse, SlackError>> entityPresentDetails(
+    WorkObjectFlexpaneParams params
+  ) {
+    return postSlackCommand(
+      SlackMethods.entity_presentDetails,
+      params,
+      EntityPresentDetailsResponse.class
+    );
   }
 
   @Override

--- a/slack-request-verifier/src/test/java/com.hubspot.slack.client.request.verifier/SlackRequestVerifierFilterTest.java
+++ b/slack-request-verifier/src/test/java/com.hubspot.slack.client.request.verifier/SlackRequestVerifierFilterTest.java
@@ -1,7 +1,8 @@
 package com.hubspot.slack.client.request.verifier;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;

--- a/slack-request-verifier/src/test/java/com.hubspot.slack.client.request.verifier/SlackRequestVerifierFilterTest.java
+++ b/slack-request-verifier/src/test/java/com.hubspot.slack.client.request.verifier/SlackRequestVerifierFilterTest.java
@@ -93,7 +93,12 @@ public class SlackRequestVerifierFilterTest {
   @Test
   public void itFailsWhileGettingResponseBody() {
     ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
-    ByteArrayInputStream inputStream = mock(ByteArrayInputStream.class);
+    InputStream inputStream = new InputStream() {
+      @Override
+      public int read() throws java.io.IOException {
+        throw new java.io.IOException("Test IOException");
+      }
+    };
 
     when(requestContext.getHeaders())
       .thenReturn(getMapHeaders(getList(1L), getList("signature")));


### PR DESCRIPTION
Description:
We, as the HubSpot Slack integration team, are continuing work on upgrading the link unfurling logic. We already support Work Objects and are going to extend this functionality further.
In this PR, I’ve added several models that will be used to add action buttons for Slack Work Objects and Flexpane, as well as to build the Work Object Flexpane itself. This PR also includes updates to the SlackClient to enable sending requests to the new entity.presentDetails Slack method.

Related issue: https://git.hubteam.com/HubSpot/slack-integration/issues/6303