### PR TITLE
Omit empty fields for the WorkObjectAction model

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/actions/WorkObjectActionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/chat/workobject/actions/WorkObjectActionIF.java
@@ -1,5 +1,6 @@
 package com.hubspot.slack.client.methods.params.chat.workobject.actions;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -9,6 +10,7 @@ import org.immutables.value.Value;
 @HubSpotStyle
 @Value.Immutable
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public interface WorkObjectActionIF {
   String getText();
   String getActionId();


### PR DESCRIPTION
In this PR, I’ve added an annotation to omit empty fields in the WorkObjectAction model