### PR TITLE
Fix issue with the deserialization of the UnknownRichTextObject

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/richtextelements/RichTextElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/richtextelements/RichTextElement.java
@@ -5,7 +5,11 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.hubspot.slack.client.models.blocks.elements.BlockElement;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  property = "type",
+  defaultImpl = UnknownRichTextElement.class
+)
 @JsonSubTypes(
   {
     @JsonSubTypes.Type(

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/richtextelements/RichTextObject.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/richtextelements/RichTextObject.java
@@ -5,7 +5,11 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.hubspot.slack.client.models.blocks.elements.BlockElement;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  property = "type",
+  defaultImpl = UnknownRichTextObject.class
+)
 @JsonSubTypes(
   {
     @JsonSubTypes.Type(value = RichTextSection.class, name = RichTextSection.TYPE),

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/richtextelements/UnknownRichTextElement.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/richtextelements/UnknownRichTextElement.java
@@ -1,0 +1,13 @@
+package com.hubspot.slack.client.models.blocks.elements.richtextelements;
+
+public class UnknownRichTextElement implements RichTextElement {
+
+  public static final String TYPE = "unknown";
+
+  protected UnknownRichTextElement() {}
+
+  @Override
+  public String getType() {
+    return TYPE;
+  }
+}

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/richtextelements/UnknownRichTextObject.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/elements/richtextelements/UnknownRichTextObject.java
@@ -1,0 +1,13 @@
+package com.hubspot.slack.client.models.blocks.elements.richtextelements;
+
+public class UnknownRichTextObject implements RichTextObject {
+
+  public static final String TYPE = "unknown";
+
+  protected UnknownRichTextObject() {}
+
+  @Override
+  public String getType() {
+    return TYPE;
+  }
+}

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/blocks/RichTextBlockDeserializationTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/blocks/RichTextBlockDeserializationTest.java
@@ -17,6 +17,7 @@ import com.hubspot.slack.client.models.blocks.elements.richtextelements.RichText
 import com.hubspot.slack.client.models.blocks.elements.richtextelements.RichTextTextElement;
 import com.hubspot.slack.client.models.blocks.elements.richtextelements.RichTextUserElement;
 import com.hubspot.slack.client.models.blocks.elements.richtextelements.RichTextUserGroupElement;
+import com.hubspot.slack.client.models.blocks.elements.richtextelements.UnknownRichTextElement;
 import java.io.IOException;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -34,6 +35,7 @@ public class RichTextBlockDeserializationTest {
   private static final int SECTION_WITH_USER_ELEMENT_INDEX = 7;
   private static final int SECTION_WITH_USERGROUP_ELEMENT_INDEX = 8;
   private static final int SECTION_WITH_MULTIPLE_ELEMENTS_INDEX = 9;
+  private static final int SECTION_WITH_UNKNOWN_ELEMENT_INDEX = 10;
   private static RichTextSection[] sections;
 
   @BeforeClass
@@ -130,6 +132,14 @@ public class RichTextBlockDeserializationTest {
       .containsExactly(
         RichTextUserGroupElement.builder().setUserGroupId("G123ABC456").build()
       );
+  }
+
+  @Test
+  public void itDeserializesUnknownElementAsUnknownBlockElement() {
+    assertThat(sections[SECTION_WITH_UNKNOWN_ELEMENT_INDEX].getElements())
+      .hasSize(1)
+      .first()
+      .isInstanceOf(UnknownRichTextElement.class);
   }
 
   @Test

--- a/slack-base/src/test/resources/rich_text_blocks.json
+++ b/slack-base/src/test/resources/rich_text_blocks.json
@@ -179,5 +179,19 @@
         ]
       }
     ]
+  },
+  {
+    "type": "rich_text",
+    "elements": [
+      {
+        "type": "rich_text_section",
+        "elements": [
+          {
+            "type": "message_mention",
+            "message_id": "1234567890.123456"
+          }
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fix the RichTextElement to handle unknown types to prevent the serialization error, which leads to missing all context instead of losing one element.