### PR TITLE
Make DataTable caption optional 

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/DataTableIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/DataTableIF.java
@@ -28,7 +28,7 @@ public interface DataTableIF extends Block {
   }
 
   @Value.Parameter(order = 1)
-  String getCaption();
+  Optional<String> getCaption();
 
   @Value.Parameter(order = 2)
   ImmutableList<ImmutableList<DataTableCell>> getRows();

--- a/slack-base/src/test/java/com/hubspot/slack/client/models/blocks/DataTableBlockTest.java
+++ b/slack-base/src/test/java/com/hubspot/slack/client/models/blocks/DataTableBlockTest.java
@@ -26,6 +26,7 @@ public class DataTableBlockTest {
   private static final int RAW_NUMBER_INDEX = 1;
   private static final int WITH_OPTIONS_INDEX = 2;
   private static final int UNKNOWN_CELL_INDEX = 3;
+  private static final int NO_CAPTION_INDEX = 4;
   private static DataTable[] blocks;
 
   @BeforeClass
@@ -48,7 +49,12 @@ public class DataTableBlockTest {
 
   @Test
   public void itDeserializesCaption() {
-    assertThat(blocks[RICH_TEXT_BODY_INDEX].getCaption()).isEqualTo("Team Directory");
+    assertThat(blocks[RICH_TEXT_BODY_INDEX].getCaption()).contains("Team Directory");
+  }
+
+  @Test
+  public void itDeserializesAbsentCaption() {
+    assertThat(blocks[NO_CAPTION_INDEX].getCaption()).isEmpty();
   }
 
   @Test

--- a/slack-base/src/test/resources/data_table_block.json
+++ b/slack-base/src/test/resources/data_table_block.json
@@ -74,5 +74,16 @@
         {"type": "future_slack_cell_type"}
       ]
     ]
+  },
+  {
+    "type": "data_table",
+    "rows": [
+      [
+        {"type": "raw_text", "text": "Header"}
+      ],
+      [
+        {"type": "raw_text", "text": "Body"}
+      ]
+    ]
   }
 ]


### PR DESCRIPTION
Changed `DataTableIF#getCaption()` return type from `String` to `Optional<String>` 

Reason:
One of our team's worker has dependency on slack client and it started to report erros with DataTableIF saying
```
Caused by: com.fasterxml.jackson.databind.exc.ValueInstantiationException: Cannot construct instance of `com.hubspot.slack.client.models.blocks.DataTable`, problem: Cannot build DataTable, some of required attributes are not set [caption]
```

[link to logFetch Errors](https://private.hubteam.com/errors/view/deployable/DevExMetricsTQ2-slack-events-message-worker/digest/8fea4d826ceabde74369d87b5ad8b7dd?timeRange=1782691200000/1783295940000)

related to https://github.com/HubSpotEngineering/DevExMetrics/issues/3216