### PR TITLE
Make threadTs optional for SetSuggestedPromptsParams

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/assistant/SetSuggestedPromptsParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/assistant/SetSuggestedPromptsParamsIF.java
@@ -17,7 +17,7 @@ public interface SetSuggestedPromptsParamsIF extends HasChannel {
     return getChannelId();
   }
 
-  String getThreadTs();
+  Optional<String> getThreadTs();
 
   Optional<String> getTitle();
 


### PR DESCRIPTION
Slack made threadTs optional for SetSuggestedPromptsParams [Slack doc ](https://docs.slack.dev/reference/methods/assistant.threads.setSuggestedPrompts/) as in the Agent view, we don't have threadTs.