### PR TITLE
Add @JsonInclude(NON_ABSENT) to optional fields in SetSuggestedPromptsParams

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/assistant/SetSuggestedPromptsParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/assistant/SetSuggestedPromptsParamsIF.java
@@ -1,5 +1,6 @@
 package com.hubspot.slack.client.methods.params.assistant;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -17,8 +18,10 @@ public interface SetSuggestedPromptsParamsIF extends HasChannel {
     return getChannelId();
   }
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   Optional<String> getThreadTs();
 
+  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   Optional<String> getTitle();
 
   List<Prompt> getPrompts();

--- a/slack-base/src/main/java/com/hubspot/slack/client/methods/params/assistant/SetSuggestedPromptsParamsIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/methods/params/assistant/SetSuggestedPromptsParamsIF.java
@@ -11,6 +11,7 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public interface SetSuggestedPromptsParamsIF extends HasChannel {
   @Value.Derived
@@ -18,10 +19,8 @@ public interface SetSuggestedPromptsParamsIF extends HasChannel {
     return getChannelId();
   }
 
-  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   Optional<String> getThreadTs();
 
-  @JsonInclude(JsonInclude.Include.NON_ABSENT)
   Optional<String> getTitle();
 
   List<Prompt> getPrompts();


### PR DESCRIPTION
Without this annotation, Optional.empty() fields are serialized as null in the JSON payload, which the Slack API may reject or misinterpret.