### PR TITLE
Tighten block validation: header text <=150 chars, section fields <=10

### DIFF
--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/HeaderIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/HeaderIF.java
@@ -33,10 +33,10 @@ public interface HeaderIF extends Block, ContainerChildBlock {
       "The text type of a Header block must be plain_text"
     );
 
-    boolean isTextLengthValid = getText().getText().length() <= 3000;
+    boolean isTextLengthValid = getText().getText().length() <= 150;
     Preconditions.checkState(
       isTextLengthValid,
-      "The text length of a Header block cannot exceed 3000 characters"
+      "The text length of a Header block cannot exceed 150 characters"
     );
   }
 }

--- a/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
+++ b/slack-base/src/main/java/com/hubspot/slack/client/models/blocks/SectionIF.java
@@ -47,6 +47,10 @@ public interface SectionIF extends Block, ContainerChildBlock {
       hasNonEmptyTextField || hasFields,
       "Must include text if not providing a list of fields"
     );
+    Preconditions.checkState(
+      getFields().size() <= 10,
+      "A Section block cannot have more than 10 fields"
+    );
     boolean fieldsTextLengthValid =
       hasFields && getFields().stream().allMatch(item -> item.getText().length() <= 3000);
     boolean textLengthValid = getText() != null && getText().getText().length() <= 3000;


### PR DESCRIPTION
Slack's Block Kit enforces these limits at the API level; enforcing them client-side gives callers an earlier, clearer error instead of a rejected API response. Small clean-up work to be done after more implementations.

Changes:

[Header block](https://docs.slack.dev/reference/block-kit/blocks/header-block) enforces a char limit of 150, not 3000
[Section block](https://docs.slack.dev/reference/block-kit/blocks/section-block) enforces a limit of fields to 10